### PR TITLE
feat: Hide navbar on home page

### DIFF
--- a/__mocks__/nextFontMock.js
+++ b/__mocks__/nextFontMock.js
@@ -1,0 +1,9 @@
+module.exports = function () {
+  return {
+    className: 'mock-font-class',
+    variable: 'mock-font-variable',
+    style: {
+      fontFamily: 'mock-font',
+    },
+  };
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,11 @@ module.exports = {
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
     // Handle image imports
     '\\.(jpg|jpeg|png|gif|webp|svg)$': '<rootDir>/__mocks__/fileMock.js',
+    // Handle module aliases
+    '^@/(.*)$': '<rootDir>/src/$1',
+    // Mock next/font
+    '^next/font/local$': '<rootDir>/__mocks__/nextFontMock.js',
+    '^next/font/google$': '<rootDir>/__mocks__/nextFontMock.js',
   },
   // Automatically clear mock calls and instances between every test
   clearMocks: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "babel-jest": "^30.0.2",
         "eslint": "^9.29.0",
         "eslint-config-next": "^15.3.4",
+        "identity-obj-proxy": "^3.0.0",
         "jest": "^30.0.2",
         "jest-environment-jsdom": "^30.0.2",
         "postcss": "^8.5.6",
@@ -5821,6 +5822,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/harmony-reflect": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
+      "dev": true,
+      "license": "(Apache-2.0 OR MPL-1.1)"
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -5984,6 +5992,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "harmony-reflect": "^1.4.6"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ignore": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "babel-jest": "^30.0.2",
     "eslint": "^9.29.0",
     "eslint-config-next": "^15.3.4",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^30.0.2",
     "jest-environment-jsdom": "^30.0.2",
     "postcss": "^8.5.6",

--- a/src/app/__tests__/layout.test.js
+++ b/src/app/__tests__/layout.test.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import RootLayout from '../layout'; // Adjust path as necessary
+import '@testing-library/jest-dom';
+import { usePathname } from 'next/navigation';
+
+// Mock next/navigation
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(),
+}));
+
+// Mock NavigationBar component
+jest.mock('@/app/components/NavigationBar', () => {
+  return function DummyNavigationBar() {
+    return <div data-testid="navbar">NavigationBar</div>;
+  };
+});
+
+describe('RootLayout', () => {
+  it('does not render NavigationBar when pathname is "/"', () => {
+    usePathname.mockImplementation(() => '/');
+    render(<RootLayout><div>Test Children</div></RootLayout>);
+    expect(screen.queryByTestId('navbar')).not.toBeInTheDocument();
+  });
+
+  it('renders NavigationBar when pathname is not "/"', () => {
+    usePathname.mockImplementation(() => '/books');
+    render(<RootLayout><div>Test Children</div></RootLayout>);
+    expect(screen.getByTestId('navbar')).toBeInTheDocument();
+  });
+});

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,4 +1,5 @@
 import localFont from "next/font/local";
+import { usePathname } from "next/navigation"; // Import usePathname
 import NavigationBar from "@/app/components/NavigationBar"; // Import NavigationBar
 import "./globals.css";
 
@@ -24,12 +25,13 @@ export const metadata = {
 // RootLayout component - The main layout component for the application.
 // It sets up the HTML structure, loads fonts, and renders child components.
 export default function RootLayout({ children }) {
+  const pathname = usePathname(); // Get current pathname
   return (
     <html lang="en">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <NavigationBar />
+        {pathname !== "/" && <NavigationBar />} {/* Conditionally render NavigationBar */}
         {children}
       </body>
     </html>


### PR DESCRIPTION
Conditionally renders the NavigationBar component based on the current pathname. The NavigationBar is now hidden on the home page ('/') and visible on all other pages.

Added tests to verify this behavior:
- Ensures NavigationBar is not present when the path is '/'.
- Ensures NavigationBar is present for other paths.