### PR TITLE
Fix: Prevent conditional useMemo call in FilterPopup

### DIFF
--- a/src/app/components/__tests__/NavigationBar.test.js
+++ b/src/app/components/__tests__/NavigationBar.test.js
@@ -9,9 +9,9 @@ jest.mock('next/navigation', () => ({
 }));
 
 describe('NavigationBar', () => {
-  it('renders the title "My Awesome App"', () => {
+  it('renders the title "Stephen King Universe"', () => {
     render(<NavigationBar />);
-    expect(screen.getByText('My Awesome App')).toBeInTheDocument();
+    expect(screen.getByText('Stephen King Universe')).toBeInTheDocument();
   });
 
   describe('Hamburger Menu', () => {

--- a/src/app/pages/books/FilterPopup.js
+++ b/src/app/pages/books/FilterPopup.js
@@ -17,8 +17,6 @@ export default function FilterPopup({
   onResetFilters,
   onClose
 }) {
-  if (!isOpen) return null;
-
   // Memoized lists for dropdowns
   const uniqueYears = useMemo(() => {
     if (!initialBooks?.data) return [];
@@ -31,6 +29,8 @@ export default function FilterPopup({
     const publishers = new Set(initialBooks.data.map(book => book.Publisher).filter(Boolean));
     return Array.from(publishers).sort(); // Ascending order
   }, [initialBooks]);
+
+  if (!isOpen) return null;
 
   // Handler for resetting filters
   const handleResetFilters = () => {


### PR DESCRIPTION
Moved the `useMemo` calls for `uniqueYears` and `uniquePublishers` in `src/app/pages/books/FilterPopup.js` to be before the early return statement (`if (!isOpen) return null;`).

This resolves the React Hook error "useMemo" is called conditionally" by ensuring that the hooks are called in the exact same order in every component render, regardless of the `isOpen` prop.

Additionally, during my work, `jest-environment-jsdom` was installed, and a snapshot in `NavigationBar.test.js` was updated to reflect the correct application title.