### PR TITLE
feat: Add Dark Territories link to navigation bar

### DIFF
--- a/src/app/components/NavigationBar.js
+++ b/src/app/components/NavigationBar.js
@@ -59,6 +59,9 @@ const NavigationBar = () => {
         <Link href="/pages/villains" className={`text-xl font-extrabold py-2 px-4 rounded-md hover:bg-gray-700 ${pathname === '/pages/villains' ? 'underline' : ''}`} onClick={handleLinkClick}>
           VILLAINS
         </Link>
+        <Link href="/pages/dark-territories" className={`text-xl font-extrabold py-2 px-4 rounded-md hover:bg-gray-700 ${pathname === '/pages/dark-territories' ? 'underline' : ''}`} onClick={handleLinkClick}>
+          DARK TERRITORIES
+        </Link>
       </div>
     </nav>
   );


### PR DESCRIPTION
Added a new link to the "Dark Territories" page in the NavigationBar.js component. The link is placed after the "VILLAINS" link and has similar styling and behavior to the existing links.