### PR TITLE
Refactor: Change filter popup to slide-in menu on Books page

### DIFF
--- a/src/app/pages/books/BookListClient.js
+++ b/src/app/pages/books/BookListClient.js
@@ -100,7 +100,7 @@ export default function BookListClient({ initialBooks }) {
   };
 
   return (
-    <div>
+    <div className={`transition-all duration-300 ease-in-out ${isFilterPopupOpen ? 'mr-80' : 'mr-0'}`}>
       {/* Button to get a random book */}
       <div className="flex justify-center my-4">
         <button

--- a/src/app/pages/books/FilterPopup.js
+++ b/src/app/pages/books/FilterPopup.js
@@ -53,9 +53,9 @@ export default function FilterPopup({
 
   return (
     // Modal backdrop and container
-    <div className="fixed inset-0 bg-black bg-opacity-75 flex justify-center items-center p-4 z-50 transition-opacity duration-300 ease-in-out">
+    <div className={`fixed top-0 right-0 h-full bg-gray-800 shadow-xl z-50 transform transition-transform duration-300 ease-in-out ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}>
       {/* Modal content box */}
-      <div className="bg-gray-800 p-6 rounded-xl shadow-2xl max-w-lg w-full max-h-[90vh] flex flex-col">
+      <div className="p-6 w-80 max-w-sm flex flex-col h-full">
         {/* Header */}
         <div className="flex justify-between items-center mb-6">
           <h2 className="text-2xl font-semibold text-white">Filter Books</h2>


### PR DESCRIPTION
I converted the modal-style filter popup on the 'Books' page into a menu that slides in from the right.

Key changes:
- Modified `FilterPopup.js`:
    - Updated styles to position the component as a slide-in panel.
    - Used Tailwind CSS transform and transition classes for the sliding animation.
    - Ensured the `isOpen` prop controls the visibility (slide in/out).
- Modified `BookListClient.js`:
    - Added a conditional right margin to the main content area.
    - This margin (`mr-80`) is applied when the filter menu is open, preventing content overlap.
    - Added a CSS transition for smooth adjustment of the content area.

The new slide-in menu improves user experience by keeping the filter options accessible without obscuring the main content of the Books page.