### PR TITLE
Feat: Implement responsive slide-in filter menu

### DIFF
--- a/src/app/pages/books/BookListClient.js
+++ b/src/app/pages/books/BookListClient.js
@@ -100,7 +100,7 @@ export default function BookListClient({ initialBooks }) {
   };
 
   return (
-    <div>
+    <div className={`transition-[margin-right] duration-300 ease-in-out ${isFilterPopupOpen ? 'md:mr-80' : 'md:mr-0'}`}>
       {/* Button to get a random book */}
       <div className="flex justify-center my-4">
         <button
@@ -130,7 +130,7 @@ export default function BookListClient({ initialBooks }) {
           <option value="year_oldest_to_newest">Year (Oldest to Newest)</option>
         </select>
         <button
-          onClick={() => setIsFilterPopupOpen(true)}
+          onClick={() => setIsFilterPopupOpen(!isFilterPopupOpen)} // Toggle behavior
           className="p-2 rounded bg-purple-600 hover:bg-purple-500 text-white font-medium"
         >
           Filters

--- a/src/app/pages/books/FilterPopup.js
+++ b/src/app/pages/books/FilterPopup.js
@@ -30,9 +30,6 @@ export default function FilterPopup({
     return Array.from(publishers).sort(); // Ascending order
   }, [initialBooks]);
 
-  // Add the conditional return for when the modal is closed
-  if (!isOpen) return null;
-
   // Handler for resetting filters
   const handleResetFilters = () => {
     setSelectedYear('');
@@ -52,10 +49,9 @@ export default function FilterPopup({
   };
 
   return (
-    // Modal backdrop and container
-    <div className="fixed inset-0 bg-black bg-opacity-75 flex justify-center items-center p-4 z-50 transition-opacity duration-300 ease-in-out">
-      {/* Modal content box */}
-      <div className="bg-gray-800 p-6 rounded-xl shadow-2xl max-w-lg w-full max-h-[90vh] flex flex-col">
+    <div className={`fixed inset-0 z-50 bg-gray-800 transform transition-transform duration-300 ease-in-out md:left-auto md:top-0 md:right-0 md:bottom-auto md:h-full md:w-80 md:shadow-xl ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}>
+      {/* Inner content wrapper */}
+      <div className="p-4 md:p-6 flex flex-col h-full">
         {/* Header */}
         <div className="flex justify-between items-center mb-6">
           <h2 className="text-2xl font-semibold text-white">Filter Books</h2>


### PR DESCRIPTION
Implements a new filter menu on the 'Books' page with responsive behavior:
- On desktop (md screens and up): Behaves as a right sidebar that slides in from the right. The main page content shifts to the left to accommodate the menu.
- On mobile (default): Behaves as a full-screen modal that slides in from the right.

Key changes:

- `src/app/pages/books/FilterPopup.js`:
    - Major refactor of styling for the main container to be responsive. - Mobile-first: `fixed inset-0 z-50 bg-gray-800` for full-screen modal. - Desktop overrides: `md:left-auto md:top-0 md:right-0 md:bottom-auto md:h-full md:w-80 md:shadow-xl` for a right sidebar.
    - Uses `transform transition-transform` with `translate-x-0` or `translate-x-full` for slide-in/out animation from the right.
    - Inner content padding is responsive (`p-4 md:p-6`).
    - Internal structure ensures filter options are scrollable (`overflow-y-auto flex-grow`) between a fixed header and footer within the popup.

- `src/app/pages/books/BookListClient.js`:
    - The main content container now has conditional right margin: `className="transition-[margin-right] duration-300 ease-in-out ${isFilterPopupOpen ? 'md:mr-80' : 'md:mr-0'}"` This shifts the content only on medium screens and up when the filter menu is open.
    - The 'Filters' button correctly toggles the `isFilterPopupOpen` state.

This implementation provides an improved user experience for filtering books across different device sizes, ensuring content visibility and accessibility of filter options.