### PR TITLE
Refactor: Apply consistent eery & minimalistic design and padding

### DIFF
--- a/src/app/pages/books/BookListClient.js
+++ b/src/app/pages/books/BookListClient.js
@@ -72,9 +72,9 @@ export default function BookListClient({ initialBooks }) {
 
   if (!initialBooks || !initialBooks.data || !Array.isArray(initialBooks.data)) {
     return (
-      <div>
-        <h1>সমস্যা</h1>
-        <p>Book data is currently unavailable or malformed. Please try again later. The filter menu has been temporarily disabled.</p>
+      <div className="px-8 py-12">
+        <h1 className="text-2xl font-bold text-[var(--accent-color)] mb-4">সমস্যা</h1>
+        <p className="text-[var(--text-color)]">Book data is currently unavailable or malformed. Please try again later. The filter menu has been temporarily disabled.</p>
       </div>
     );
   }
@@ -100,11 +100,12 @@ export default function BookListClient({ initialBooks }) {
   };
 
   return (
-    <div className={`transition-[margin-right] duration-300 ease-in-out ${isFilterPopupOpen ? 'md:mr-80' : 'md:mr-0'}`}>
+    <div className={`px-8 py-12 transition-[margin-right] duration-300 ease-in-out ${isFilterPopupOpen ? 'md:mr-80' : 'md:mr-0'}`}>
+      <h1 className="text-5xl md:text-6xl mb-4 text-center text-[var(--text-color)]" style={{ fontFamily: 'Georgia, serif' }}>Books</h1>
       {/* Button to get a random book */}
       <div className="flex justify-center my-4">
         <button
-          className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+          className="bg-[var(--accent-color)] hover:bg-[var(--hover-accent-color)] text-[var(--text-color)] font-bold py-2 px-4 rounded"
           onClick={handleRandomBook}
         >
           Get Random Book
@@ -112,16 +113,16 @@ export default function BookListClient({ initialBooks }) {
       </div>
       
       {/* Search and Sort Controls */}
-      <div className="mb-4 p-4 bg-gray-800 rounded-lg shadow flex gap-4">
+      <div className="mb-4 p-4 bg-[var(--background-color)] rounded-lg shadow flex flex-wrap gap-4 items-center">
          <input
              type="text"
              placeholder="Search books..."
-             className="w-full p-2 rounded bg-gray-700 text-white"
+             className="w-full md:w-auto flex-grow p-2 rounded bg-[var(--background-color)] text-[var(--text-color)] border border-[var(--accent-color)] focus:border-[var(--hover-accent-color)] focus:ring-1 focus:ring-[var(--hover-accent-color)]"
              value={searchTerm}
              onChange={(e) => setSearchTerm(e.target.value)}
          />
          <select
-          className="p-2 rounded bg-gray-700 text-white"
+          className="p-2 rounded bg-[var(--background-color)] text-[var(--text-color)] border border-[var(--accent-color)] focus:border-[var(--hover-accent-color)] focus:ring-1 focus:ring-[var(--hover-accent-color)]"
           value={sortOrder}
           onChange={(e) => setSortOrder(e.target.value)}
         >
@@ -131,7 +132,7 @@ export default function BookListClient({ initialBooks }) {
         </select>
         <button
           onClick={() => setIsFilterPopupOpen(!isFilterPopupOpen)} // Toggle behavior
-          className="p-2 rounded bg-purple-600 hover:bg-purple-500 text-white font-medium"
+          className="bg-[var(--accent-color)] hover:bg-[var(--hover-accent-color)] text-[var(--text-color)] font-bold py-2 px-4 rounded"
         >
           Filters
         </button>
@@ -168,22 +169,23 @@ export default function BookListClient({ initialBooks }) {
       {/* Renders the list of filtered books */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
          {filteredBooks.map(book => (
-             <div key={book.id} className="p-4 bg-gray-800 rounded-lg shadow hover:bg-gray-700 transition-colors">
-                 <h2 className="text-xl font-semibold text-purple-400">
+             <div key={book.id} className="p-4 bg-[var(--background-color)] rounded-lg shadow border border-[var(--accent-color)] hover:border-[var(--hover-accent-color)] transition-colors">
+                 <h2 className="text-xl font-semibold text-[var(--accent-color)] hover:text-[var(--hover-accent-color)]">
                      <Link href={`/pages/books/${book.id}`}>
                          {book.Title}
                      </Link>
                  </h2>
                  {/* Add any other brief details if desired, e.g., book.status */}
-                 {book.Year && <p className="text-sm text-gray-400">Year: {book.Year}</p>}
-                 {book.status && <p className="text-sm text-gray-400">Status: {book.status}</p>}
+                 {book.Year && <p className="text-sm text-[var(--text-color)]">Year: {book.Year}</p>}
+                 {book.status && <p className="text-sm text-[var(--text-color)]">Status: {book.status}</p>}
              </div>
          ))}
      </div>
      {/* Display a message if no books match the search term */}
      {filteredBooks.length === 0 && searchTerm && (
-         <p className="text-center text-gray-400 mt-4">No books found matching your search.</p>
+         <p className="text-center text-[var(--text-color)] mt-4">No books found matching your search.</p>
      )}
+      <div className="text-center mt-12"><Link href="/" className="home-link text-xl">Return to Home</Link></div>
     </div>
   );
 }

--- a/src/app/pages/books/FilterPopup.js
+++ b/src/app/pages/books/FilterPopup.js
@@ -49,15 +49,15 @@ export default function FilterPopup({
   };
 
   return (
-    <div className={`fixed inset-0 z-50 bg-gray-800 transform transition-transform duration-300 ease-in-out md:left-auto md:top-0 md:right-0 md:bottom-auto md:h-full md:w-80 md:shadow-xl ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}>
+    <div className={`fixed inset-0 z-50 bg-[var(--background-color)] border border-[var(--accent-color)] transform transition-transform duration-300 ease-in-out md:left-auto md:top-0 md:right-0 md:bottom-auto md:h-full md:w-80 md:shadow-xl ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}>
       {/* Inner content wrapper */}
-      <div className="p-4 md:p-6 flex flex-col h-full">
+      <div className="p-6 flex flex-col h-full">
         {/* Header */}
         <div className="flex justify-between items-center mb-6">
-          <h2 className="text-2xl font-semibold text-white">Filter Books</h2>
+          <h2 className="text-2xl font-semibold text-[var(--text-color)]">Filter Books</h2>
           <button
             onClick={onClose} // onClick should call the onClose prop
-            className="text-gray-400 hover:text-red-500 text-3xl font-bold leading-none"
+            className="text-[var(--accent-color)] hover:text-[var(--hover-accent-color)] text-3xl font-bold leading-none"
             aria-label="Close"
           >
             &times;
@@ -65,15 +65,15 @@ export default function FilterPopup({
         </div>
 
         {/* Scrollable filter options */}
-        <div className="overflow-y-auto pr-2 flex-grow">
+        <div className="overflow-y-auto pr-2 flex-grow space-y-4">
           {/* Year Filter */}
-          <div className="mb-5">
-            <label htmlFor="filter-year" className="block text-sm font-medium text-gray-300 mb-1">Year</label>
+          <div>
+            <label htmlFor="filter-year" className="block text-sm font-medium text-[var(--text-color)] mb-1">Year</label>
             <select
               id="filter-year"
               value={selectedYear}
               onChange={(e) => setSelectedYear(e.target.value)}
-              className="w-full p-3 rounded-md bg-gray-700 text-white border border-gray-600 focus:ring-2 focus:ring-purple-500 focus:border-purple-500 outline-none"
+              className="w-full p-2 rounded bg-[var(--background-color)] text-[var(--text-color)] border border-[var(--accent-color)] focus:border-[var(--hover-accent-color)] focus:ring-1 focus:ring-[var(--hover-accent-color)] outline-none"
             >
               <option value="">All Years</option>
               {uniqueYears.map(year => (
@@ -83,13 +83,13 @@ export default function FilterPopup({
           </div>
 
           {/* Publisher Filter */}
-          <div className="mb-5">
-            <label htmlFor="filter-publisher" className="block text-sm font-medium text-gray-300 mb-1">Publisher</label>
+          <div>
+            <label htmlFor="filter-publisher" className="block text-sm font-medium text-[var(--text-color)] mb-1">Publisher</label>
             <select
               id="filter-publisher"
               value={selectedPublisher}
               onChange={(e) => setSelectedPublisher(e.target.value)}
-              className="w-full p-3 rounded-md bg-gray-700 text-white border border-gray-600 focus:ring-2 focus:ring-purple-500 focus:border-purple-500 outline-none"
+              className="w-full p-2 rounded bg-[var(--background-color)] text-[var(--text-color)] border border-[var(--accent-color)] focus:border-[var(--hover-accent-color)] focus:ring-1 focus:ring-[var(--hover-accent-color)] outline-none"
             >
               <option value="">All Publishers</option>
               {uniquePublishers.map(publisher => (
@@ -99,15 +99,15 @@ export default function FilterPopup({
           </div>
 
           {/* Page Count Filter */}
-          <div className="mb-5">
-            <label className="block text-sm font-medium text-gray-300 mb-1">Page Count</label>
-            <div className="flex gap-3">
+          <div>
+            <label className="block text-sm font-medium text-[var(--text-color)] mb-1">Page Count</label>
+            <div className="flex gap-4">
               <input
                 type="number"
                 placeholder="Min Pages"
                 value={minPages}
                 onChange={(e) => setMinPages(e.target.value)}
-                className="w-full p-3 rounded-md bg-gray-700 text-white border border-gray-600 focus:ring-2 focus:ring-purple-500 focus:border-purple-500 outline-none"
+                className="w-full p-2 rounded bg-[var(--background-color)] text-[var(--text-color)] border border-[var(--accent-color)] focus:border-[var(--hover-accent-color)] focus:ring-1 focus:ring-[var(--hover-accent-color)] outline-none"
                 min="0"
               />
               <input
@@ -115,7 +115,7 @@ export default function FilterPopup({
                 placeholder="Max Pages"
                 value={maxPages}
                 onChange={(e) => setMaxPages(e.target.value)}
-                className="w-full p-3 rounded-md bg-gray-700 text-white border border-gray-600 focus:ring-2 focus:ring-purple-500 focus:border-purple-500 outline-none"
+                className="w-full p-2 rounded bg-[var(--background-color)] text-[var(--text-color)] border border-[var(--accent-color)] focus:border-[var(--hover-accent-color)] focus:ring-1 focus:ring-[var(--hover-accent-color)] outline-none"
                 min="0"
               />
             </div>
@@ -123,16 +123,16 @@ export default function FilterPopup({
         </div>
 
         {/* Action Buttons */}
-        <div className="flex justify-end gap-4 mt-6 pt-4 border-t border-gray-700">
+        <div className="flex justify-end gap-4 mt-6 pt-4 border-t border-[var(--accent-color)]">
           <button
             onClick={handleResetFilters}
-            className="px-5 py-2.5 rounded-md bg-gray-600 hover:bg-gray-500 text-white font-medium transition-colors duration-150 ease-in-out"
+            className="bg-[var(--accent-color)] hover:bg-[var(--hover-accent-color)] text-[var(--text-color)] font-bold py-2 px-4 rounded"
           >
             Reset Filters
           </button>
           <button
             onClick={handleApplyFilters}
-            className="px-5 py-2.5 rounded-md bg-purple-600 hover:bg-purple-500 text-white font-medium transition-colors duration-150 ease-in-out"
+            className="bg-[var(--accent-color)] hover:bg-[var(--hover-accent-color)] text-[var(--text-color)] font-bold py-2 px-4 rounded"
           >
             Apply Filters
           </button>

--- a/src/app/pages/shorts/ShortListClient.js
+++ b/src/app/pages/shorts/ShortListClient.js
@@ -56,11 +56,12 @@ export default function ShortListClient({ initialShorts }) {
   };
 
   return (
-    <div>
+    <div className="px-8 py-12">
+      <h1 className="text-5xl md:text-6xl mb-4 text-center text-[var(--text-color)]" style={{ fontFamily: 'Georgia, serif' }}>Short Stories</h1>
       {/* Button to get a random short story */}
       <div className="flex justify-center my-4">
         <button
-          className="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded"
+          className="bg-[var(--accent-color)] hover:bg-[var(--hover-accent-color)] text-[var(--text-color)] font-bold py-2 px-4 rounded"
           onClick={handleRandomShort}
         >
           Get Random Short Story
@@ -68,16 +69,16 @@ export default function ShortListClient({ initialShorts }) {
       </div>
 
       {/* Search and Sort Controls */}
-      <div className="mb-4 p-4 bg-gray-800 rounded-lg shadow flex gap-4">
+      <div className="mb-4 p-4 bg-[var(--background-color)] rounded-lg shadow flex flex-wrap gap-4 items-center">
          <input
              type="text"
              placeholder="Search shorts..."
-             className="w-full p-2 rounded bg-gray-700 text-white"
+             className="w-full md:w-auto flex-grow p-2 rounded bg-[var(--background-color)] text-[var(--text-color)] border border-[var(--accent-color)] focus:border-[var(--hover-accent-color)] focus:ring-1 focus:ring-[var(--hover-accent-color)]"
              value={searchTerm}
              onChange={(e) => setSearchTerm(e.target.value)}
          />
          <select
-          className="p-2 rounded bg-gray-700 text-white"
+          className="p-2 rounded bg-[var(--background-color)] text-[var(--text-color)] border border-[var(--accent-color)] focus:border-[var(--hover-accent-color)] focus:ring-1 focus:ring-[var(--hover-accent-color)]"
           value={sortOrder}
           onChange={(e) => setSortOrder(e.target.value)}
         >
@@ -91,22 +92,23 @@ export default function ShortListClient({ initialShorts }) {
       {/* Renders the list of filtered short stories */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
          {filteredShorts.map(short => (
-             <div key={short.id} className="p-4 bg-gray-800 rounded-lg shadow hover:bg-gray-700 transition-colors">
-                 <h2 className="text-xl font-semibold text-purple-400">
+             <div key={short.id} className="p-4 bg-[var(--background-color)] rounded-lg shadow border border-[var(--accent-color)] hover:border-[var(--hover-accent-color)] transition-colors">
+                 <h2 className="text-xl font-semibold text-[var(--accent-color)] hover:text-[var(--hover-accent-color)]">
                      <Link href={`/pages/shorts/${short.id}`}>
                          {short.title}
                      </Link>
                  </h2>
                  {/* Add any other brief details if desired, e.g., short.status */}
-                 {short.year && <p className="text-sm text-gray-400">Year: {short.year}</p>}
-                 {short.status && <p className="text-sm text-gray-400">Status: {short.status}</p>}
+                 {short.year && <p className="text-sm text-[var(--text-color)] opacity-75">Year: {short.year}</p>}
+                 {short.status && <p className="text-sm text-[var(--text-color)] opacity-75">Status: {short.status}</p>}
              </div>
          ))}
      </div>
      {/* Display a message if no short stories match the search term */}
      {filteredShorts.length === 0 && searchTerm && (
-         <p className="text-center text-gray-400 mt-4">No shorts found matching your search.</p>
+         <p className="text-center text-[var(--text-color)] mt-4">No shorts found matching your search.</p>
      )}
+      <div className="text-center mt-12"><Link href="/" className="home-link text-xl">Return to Home</Link></div>
     </div>
   );
 }

--- a/src/app/pages/villains/VillainListClient.js
+++ b/src/app/pages/villains/VillainListClient.js
@@ -44,11 +44,12 @@ export default function VillainListClient({ initialVillains }) {
   };
 
   return (
-    <div>
+    <div className="px-8 py-12">
+      <h1 className="text-5xl md:text-6xl mb-4 text-center text-[var(--text-color)]" style={{ fontFamily: 'Georgia, serif' }}>Villains</h1>
       {/* Button to get a random villain */}
       <div className="flex justify-center my-4">
         <button
-          className="bg-purple-500 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded"
+          className="bg-[var(--accent-color)] hover:bg-[var(--hover-accent-color)] text-[var(--text-color)] font-bold py-2 px-4 rounded"
           onClick={handleRandomVillain}
         >
           Get Random Villain
@@ -56,11 +57,11 @@ export default function VillainListClient({ initialVillains }) {
       </div>
 
       {/* Search input */}
-      <div className="mb-4 p-4 bg-gray-800 rounded-lg shadow">
+      <div className="mb-4 p-4 bg-[var(--background-color)] rounded-lg shadow">
          <input
              type="text"
              placeholder="Search villains..."
-             className="w-full p-2 rounded bg-gray-700 text-white"
+             className="w-full p-2 rounded bg-[var(--background-color)] text-[var(--text-color)] border border-[var(--accent-color)] focus:border-[var(--hover-accent-color)] focus:ring-1 focus:ring-[var(--hover-accent-color)]"
              value={searchTerm}
              onChange={(e) => setSearchTerm(e.target.value)}
          />
@@ -70,22 +71,23 @@ export default function VillainListClient({ initialVillains }) {
       {/* Renders the list of filtered villains */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
          {filteredVillains.map(villain => (
-             <div key={villain.id} className="p-4 bg-gray-800 rounded-lg shadow hover:bg-gray-700 transition-colors">
-                 <h2 className="text-xl font-semibold text-purple-400">
+             <div key={villain.id} className="p-4 bg-[var(--background-color)] rounded-lg shadow border border-[var(--accent-color)] hover:border-[var(--hover-accent-color)] transition-colors">
+                 <h2 className="text-xl font-semibold text-[var(--accent-color)] hover:text-[var(--hover-accent-color)]">
                      <Link href={`/pages/villains/${villain.id}`}>
                          {villain.name}
                      </Link>
                  </h2>
                  {/* Add any other brief details if desired, e.g., villain.status */}
-                 {villain.status && <p className="text-sm text-gray-400">Status: {villain.status}</p>}
+                 {villain.status && <p className="text-sm text-[var(--text-color)] opacity-75">Status: {villain.status}</p>}
              </div>
          ))}
      </div>
      {/* Display a message if no villains match the search term */}
      {filteredVillains.length === 0 && searchTerm && (
-         <p className="text-center text-gray-400 mt-4">No villains found matching your search.</p>
+         <p className="text-center text-[var(--text-color)] mt-4">No villains found matching your search.</p>
      )}
 
+      <div className="text-center mt-12"><Link href="/" className="home-link text-xl">Return to Home</Link></div>
     </div>
   );
 }


### PR DESCRIPTION
I've applied the 'eery & minimalistic' design theme (defined in globals.css) across your 'Books', 'Shorts', and 'Villains' pages to match the 'Home' and 'Dark Territories' pages.

Key changes I made:
- Replaced hardcoded Tailwind CSS color classes with CSS variables (e.g., var(--background-color), var(--text-color), var(--accent-color)) in BookListClient.js, ShortListClient.js, VillainListClient.js, and FilterPopup.js.
- Standardized padding:
    - Main content containers now use px-8 py-12.
    - Consistent p-4 and gap-4 for internal elements.
- Styled interactive elements (buttons, inputs, links) to align with the theme.
- Added page titles (e.g., "Books", "Short Stories") to the respective pages for better context, styled like other main page titles.
- Added "Return to Home" links at the bottom of these pages, styled consistently with the rest of the site.

These changes ensure a unified look and feel across the application, improving your experience and code maintainability.