### PR TITLE
feat: Integrate Google Books API key for fetching covers

### DIFF
--- a/src/app/components/request.js
+++ b/src/app/components/request.js
@@ -1,4 +1,5 @@
 export default async function Request(parameter) {
+    const apiKey = process.env.NEXT_PUBLIC_GOOGLE_BOOKS_API_KEY;
     const url = 'https://stephen-king-api.onrender.com/api/';
     const headers = new Headers({
       "User-Agent": "fetch-open-data/1.0"
@@ -12,6 +13,65 @@ export default async function Request(parameter) {
       }
       data = await response.json();
   
+      // Fetch cover images
+      if (data && data.data) {
+        const booksToProcess = Array.isArray(data.data) ? data.data : [data.data]; // Handle single book or array
+        for (const book of booksToProcess) {
+          let googleBooksApiUrl;
+          if (book.ISBN) {
+            googleBooksApiUrl = `https://www.googleapis.com/books/v1/volumes?q=isbn:${book.ISBN}`;
+          } else if (book.Title) {
+            googleBooksApiUrl = `https://www.googleapis.com/books/v1/volumes?q=intitle:${encodeURIComponent(book.Title)}`;
+          } else {
+            book.coverImageUrl = "NO_COVER_AVAILABLE";
+            book.largeCoverImageUrl = "NO_COVER_AVAILABLE";
+            continue; // Skip if no ISBN or Title
+          }
+
+          // Append API key if available
+          if (googleBooksApiUrl && apiKey) {
+            googleBooksApiUrl += `&key=${apiKey}`;
+          } else if (googleBooksApiUrl && !apiKey) {
+            // Only log warning once to avoid flooding console if many books are processed
+            if (!global.apiKeyWarningLogged) {
+              console.warn("Google Books API key (NEXT_PUBLIC_GOOGLE_BOOKS_API_KEY) is missing. Requests may fail or be rate-limited.");
+              global.apiKeyWarningLogged = true; // Set flag to prevent further warnings in this session
+            }
+          }
+
+          try {
+            const googleBooksResponse = await fetch(googleBooksApiUrl);
+            if (!googleBooksResponse.ok) {
+              throw new Error(`Google Books API error: Status ${googleBooksResponse.status}`);
+            }
+            const googleBooksData = await googleBooksResponse.json();
+
+            const imageLinks = googleBooksData?.items?.[0]?.volumeInfo?.imageLinks;
+            if (imageLinks) {
+              // Thumbnail image
+              book.coverImageUrl = imageLinks.thumbnail || imageLinks.smallThumbnail || "NO_COVER_AVAILABLE";
+
+              // Larger image: medium, then large, then small
+              if (imageLinks.medium) {
+                book.largeCoverImageUrl = imageLinks.medium;
+              } else if (imageLinks.large) {
+                book.largeCoverImageUrl = imageLinks.large;
+              } else if (imageLinks.small) {
+                book.largeCoverImageUrl = imageLinks.small;
+              } else {
+                book.largeCoverImageUrl = "NO_COVER_AVAILABLE";
+              }
+            } else {
+              book.coverImageUrl = "NO_COVER_AVAILABLE";
+              book.largeCoverImageUrl = "NO_COVER_AVAILABLE";
+            }
+          } catch (err) {
+            console.log(`Error fetching cover for ${book.Title}: ${err.message}`); // Log only err.message for brevity
+            book.coverImageUrl = "NO_COVER_AVAILABLE";
+            book.largeCoverImageUrl = "NO_COVER_AVAILABLE";
+          }
+        }
+      }
     } catch (err) {
       console.log(err);
     }

--- a/src/app/pages/books/BookListClient.js
+++ b/src/app/pages/books/BookListClient.js
@@ -169,7 +169,37 @@ export default function BookListClient({ initialBooks }) {
       {/* Renders the list of filtered books */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
          {filteredBooks.map(book => (
-             <div key={book.id} className="p-4 bg-[var(--background-color)] rounded-lg shadow border border-[var(--accent-color)] hover:border-[var(--hover-accent-color)] transition-colors">
+             <div key={book.id} className="p-4 bg-[var(--background-color)] rounded-lg shadow border border-[var(--accent-color)] hover:border-[var(--hover-accent-color)] transition-colors flex flex-col">
+                 {book.coverImageUrl && book.coverImageUrl !== "NO_COVER_AVAILABLE" ? (
+                   <img
+                     src={book.coverImageUrl}
+                     alt={`Cover of ${book.Title}`}
+                     style={{
+                       width: "100%",
+                       height: "200px", // Fixed height
+                       objectFit: "cover",
+                       marginBottom: "0.5rem",
+                       borderRadius: "0.25rem" // Optional: adds rounded corners
+                     }}
+                   />
+                 ) : (
+                   <div
+                     style={{
+                       width: "100%",
+                       height: "200px", // Fixed height
+                       maxHeight: "200px",
+                       display: "flex",
+                       alignItems: "center",
+                       justifyContent: "center",
+                       backgroundColor: "#e0e0e0", // A light gray background
+                       color: "#555", // Darker text color for contrast
+                       marginBottom: "0.5rem",
+                       borderRadius: "0.25rem" // Optional: adds rounded corners
+                     }}
+                   >
+                     No Cover Available
+                   </div>
+                 )}
                  <h2 className="text-xl font-semibold text-[var(--accent-color)] hover:text-[var(--hover-accent-color)]">
                      <Link href={`/pages/books/${book.id}`}>
                          {book.Title}

--- a/src/app/pages/books/[id]/page.js
+++ b/src/app/pages/books/[id]/page.js
@@ -19,6 +19,38 @@ export default async function BookDetailPage({ params }) {
 
   return (
     <div className="container mx-auto p-4">
+      {/* Book Cover Image or Placeholder */}
+      {book.largeCoverImageUrl && book.largeCoverImageUrl !== "NO_COVER_AVAILABLE" ? (
+        <img
+          src={book.largeCoverImageUrl}
+          alt={`Cover of ${book.Title}`}
+          style={{
+            display: "block",
+            maxWidth: "400px",
+            width: "100%",
+            height: "auto",
+            margin: "0 auto 1.5rem auto",
+            borderRadius: "0.5rem",
+          }}
+        />
+      ) : (
+        <div
+          style={{
+            width: "100%",
+            maxWidth: "400px",
+            height: "300px",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            backgroundColor: "#e0e0e0",
+            color: "#555",
+            margin: "0 auto 1.5rem auto",
+            borderRadius: "0.5rem",
+          }}
+        >
+          No Cover Available
+        </div>
+      )}
       <h1 className="text-3xl font-bold mb-4">{book.Title}</h1>
       <p className="mb-2"><strong>Year:</strong> {book.Year}</p>
       <p className="mb-2"><strong>Publisher:</strong> {book.Publisher}</p>


### PR DESCRIPTION
- Modified `src/app/components/request.js` to use an API key when querying the Google Books API.
- The API key is expected to be provided via the `NEXT_PUBLIC_GOOGLE_BOOKS_API_KEY` environment variable.
- If the API key is present, it's appended to Google Books API requests, enabling access to book cover images.
- A console warning is logged if the API key is not found in the environment.

This change allows the application to display actual book covers, assuming you provide a valid API key in the `.env.local` file. The `.env.local` file itself is not (and should not be) committed.