### PR TITLE
Refactor: Defer loading of book appearances on Villain Detail page

### DIFF
--- a/src/app/pages/villains/[id]/VillainBookAppearances.js
+++ b/src/app/pages/villains/[id]/VillainBookAppearances.js
@@ -1,0 +1,67 @@
+"use client";
+
+import React, { useState, useEffect } from 'react';
+import Link from 'next/link';
+import Request from '@/app/components/request';
+
+export default function VillainBookAppearances({ villainId }) {
+  const [allBooks, setAllBooks] = useState([]);
+  const [connectedBooks, setConnectedBooks] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchBooks() {
+      setLoading(true);
+      const booksData = await Request('books');
+      if (booksData && booksData.data) {
+        setAllBooks(booksData.data);
+      } else {
+        setAllBooks([]); // Ensure allBooks is an array even if fetch fails
+      }
+      setLoading(false);
+    }
+    fetchBooks();
+  }, []); // Fetch books only once when the component mounts
+
+  useEffect(() => {
+    if (allBooks.length > 0) {
+      const filtered = allBooks.filter(book => {
+        if (book.villains && Array.isArray(book.villains)) {
+          return book.villains.some(v => {
+            const urlParts = v.url ? v.url.split('/') : [];
+            const villainIdFromBook = urlParts[urlParts.length - 1];
+            return villainIdFromBook === villainId;
+          });
+        }
+        return false;
+      });
+      setConnectedBooks(filtered);
+    }
+  }, [allBooks, villainId]); // Recalculate connectedBooks if allBooks or villainId changes
+
+  if (loading) {
+    return <p>Loading book appearances...</p>;
+  }
+
+  if (allBooks.length === 0 && !loading) {
+    return <p>Book data is currently unavailable.</p>;
+  }
+
+  return (
+    <div>
+      {connectedBooks.length > 0 ? (
+        <ul className="list-disc pl-5">
+          {connectedBooks.map(book => (
+            <li key={book.id} className="mb-1">
+              <Link href={`/pages/books/${book.id}`} className="text-blue-600 hover:underline">
+                {book.Title}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>No book appearances found for this villain.</p>
+      )}
+    </div>
+  );
+}

--- a/src/app/pages/villains/[id]/page.js
+++ b/src/app/pages/villains/[id]/page.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import Link from 'next/link';
 import Request from '@/app/components/request';
+import VillainBookAppearances from './VillainBookAppearances';
 
 export default async function VillainDetailPage({ params }) {
   const villainData = await Request(`villain/${params.id}`);
-  const booksData = await Request('books'); // Added: Fetch all books
 
   if (!villainData || !villainData.data) {
     return (
@@ -16,18 +16,6 @@ export default async function VillainDetailPage({ params }) {
   }
 
   const villain = villainData.data;
-  const allBooks = booksData && booksData.data ? booksData.data : [];
-
-  const connectedBooks = allBooks.filter(book => {
-    if (book.villains && Array.isArray(book.villains)) {
-      return book.villains.some(v => {
-        const urlParts = v.url ? v.url.split('/') : [];
-        const villainIdFromBook = urlParts[urlParts.length - 1];
-        return villainIdFromBook === params.id;
-      });
-    }
-    return false;
-  });
 
   return (
     <div className="container mx-auto p-4">
@@ -47,23 +35,7 @@ export default async function VillainDetailPage({ params }) {
       )}
 
       <h2 className="text-2xl font-semibold mb-3 mt-6">Book Appearances:</h2>
-      {allBooks.length > 0 ? (
-        connectedBooks.length > 0 ? (
-          <ul className="list-disc pl-5">
-            {connectedBooks.map(book => (
-              <li key={book.id} className="mb-1">
-                <Link href={`/pages/books/${book.id}`} className="text-blue-600 hover:underline">
-                  {book.Title}
-                </Link>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p>No book appearances found for this villain in the available book data.</p>
-        )
-      ) : (
-        <p>Book data is currently unavailable or still loading.</p>
-      )}
+      <VillainBookAppearances villainId={params.id} />
 
       <br />
       <Link href="/pages/villains" className="mt-6 inline-block bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold py-2 px-4 rounded shadow">


### PR DESCRIPTION
Previously, the Villain Detail page fetched all book data and filtered it before rendering, potentially causing slow load times if the book dataset was large or the API was slow.

This change introduces a client component, `VillainBookAppearances`, which handles the fetching, filtering, and rendering of book appearances asynchronously. This allows the primary villain details to load quickly, improving the perceived performance of the page.