### PR TITLE
Add 2-second delay to book pages for Vercel timing diagnosis

### DIFF
--- a/src/app/pages/books/[id]/page.js
+++ b/src/app/pages/books/[id]/page.js
@@ -3,10 +3,22 @@ import Link from 'next/link';
 import Image from 'next/image'; // Import Next.js Image component
 import Request from '@/app/components/request';
 
+const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
 export default async function BookDetailPage({ params }) {
+  console.log(`[/pages/books/[id]/page.js] Server Component for book ID ${params.id} started.`);
+
+  // Artificial delay for testing Vercel timing issues
+  console.log(`[/pages/books/[id]/page.js] Starting 2-second artificial delay for book ID ${params.id}...`);
+  await delay(2000);
+  console.log(`[/pages/books/[id]/page.js] Finished 2-second artificial delay for book ID ${params.id}.`);
+
+  console.log(`[/pages/books/[id]/page.js] Attempting to call Request('book/${params.id}').`);
   const bookData = await Request(`book/${params.id}`);
+  console.log(`[/pages/books/[id]/page.js] Call to Request('book/${params.id}') completed.`);
 
   if (!bookData || !bookData.data) {
+    console.warn(`[/pages/books/[id]/page.js] No bookData or bookData.data found for ID ${params.id}.`);
     return (
       <div className="container mx-auto p-4 py-8 text-center">
         <h1 className="text-3xl font-bold text-[var(--accent-color)] mb-4">Book Not Found</h1>

--- a/src/app/pages/books/page.js
+++ b/src/app/pages/books/page.js
@@ -1,9 +1,35 @@
 import Request from "@/app/components/request";
 import BookListClient from "./BookListClient"; // Import the new client component
 
-export default async function Page() {
-    const booksData = await Request('books'); // Renamed to booksData for clarity
+const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
+export default async function Page() {
+    console.log("[/pages/books/page.js] Server Component execution started.");
+
+    // Artificial delay for testing Vercel timing issues
+    console.log("[/pages/books/page.js] Starting 2-second artificial delay...");
+    await delay(2000);
+    console.log("[/pages/books/page.js] Finished 2-second artificial delay.");
+
+    let booksData;
+    try {
+      console.log("[/pages/books/page.js] Attempting to call Request('books').");
+      booksData = await Request('books');
+      console.log("[/pages/books/page.js] Call to Request('books') completed.");
+      if (booksData && booksData.data) {
+        console.log(`[/pages/books/page.js] Request('books') returned ${booksData.data.length} items in data.`);
+      } else if (booksData) {
+        console.log("[/pages/books/page.js] Request('books') returned data, but no 'data' property or it's empty:", booksData);
+      } else {
+        console.log("[/pages/books/page.js] Request('books') returned no data (undefined or null).");
+      }
+    } catch (error) {
+      console.error("[/pages/books/page.js] Error during Request('books') call:", error);
+      // Optionally, set booksData to a default error state to pass to client
+      booksData = { error: "Failed to load book data.", data: [] };
+    }
+
+    console.log("[/pages/books/page.js] Preparing to render BookListClient.");
     return (
       <div>
         <BookListClient initialBooks={booksData} /> {/* Pass data to client component */}


### PR DESCRIPTION
This commit introduces an artificial 2-second delay at the beginning of the server component execution for:
- `src/app/pages/books/page.js`
- `src/app/pages/books/[id]/page.js`

This is a diagnostic step to test the hypothesis that timing issues or race conditions in the Vercel serverless environment might be affecting the completion of data fetching operations, particularly those involving multiple calls to the Google Books API within the `Request` component. Observing behavior with this delay will help confirm if giving more 'breathing room' allows data to load consistently.