### PR TITLE
Refactor: Replace img tags with next/image component

### DIFF
--- a/src/app/pages/books/BookListClient.js
+++ b/src/app/pages/books/BookListClient.js
@@ -3,7 +3,7 @@
 import React, { useState, useMemo, Suspense } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-// import Image from 'next/image'; // Import Next.js Image component - REMOVED
+import Image from 'next/image'; // Import Next.js Image component
 import dynamic from 'next/dynamic';
 
 const FilterPopup = dynamic(() => import('./FilterPopup'), {
@@ -176,11 +176,13 @@ export default function BookListClient({ initialBooks }) {
                 {/* Book Cover Image */}
                 <div className="relative w-full h-72 flex items-center justify-center bg-neutral-700 overflow-hidden rounded-t-lg">
                   {book.coverImageUrl && book.coverImageUrl !== "NO_COVER_AVAILABLE" ? (
-                    <img
+                    <Image
                       src={book.coverImageUrl}
                       alt={`Cover of ${book.Title}`}
-                      className="w-full h-full object-contain transition-transform duration-300 group-hover:scale-105 rounded-t-lg"
-                      loading={index < 8 ? "eager" : "lazy"} // Approximate priority with eager loading for first few images
+                      fill
+                      style={{ objectFit: "contain" }}
+                      className="transition-transform duration-300 group-hover:scale-105 rounded-t-lg"
+                      priority={index < 8} // Approximate priority with eager loading for first few images
                     />
                   ) : (
                     <div

--- a/src/app/pages/google-books/[id]/page.js
+++ b/src/app/pages/google-books/[id]/page.js
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import { useParams } from 'next/navigation'; // Correct hook for App Router
 import Link from 'next/link';
+import Image from 'next/image';
 
 export default function BookDetailsPage() {
   const params = useParams(); // Hook to access route parameters
@@ -69,14 +70,17 @@ export default function BookDetailsPage() {
       </Link>
 
       <div className="bg-white shadow-xl rounded-lg overflow-hidden md:flex">
-        {volumeInfo.imageLinks?.large || volumeInfo.imageLinks?.medium || volumeInfo.imageLinks?.thumbnail ? (
-          <img
-            src={volumeInfo.imageLinks?.large || volumeInfo.imageLinks?.medium || volumeInfo.imageLinks?.thumbnail}
-            alt={`Cover of ${volumeInfo.title}`}
-            className="w-full md:w-1/3 h-auto object-contain p-4"
-          />
-        ) : (
-          <div className="w-full md:w-1/3 h-96 bg-gray-200 flex items-center justify-center text-gray-500 p-4">
+        <div className="relative w-full md:w-1/3 h-96 p-4"> {/* Added position: relative and defined height */}
+          {volumeInfo.imageLinks?.large || volumeInfo.imageLinks?.medium || volumeInfo.imageLinks?.thumbnail ? (
+            <Image
+              src={volumeInfo.imageLinks?.large || volumeInfo.imageLinks?.medium || volumeInfo.imageLinks?.thumbnail}
+              alt={`Cover of ${volumeInfo.title}`}
+              fill
+              style={{ objectFit: "contain" }}
+              priority
+            />
+          ) : (
+            <div className="w-full h-full bg-gray-200 flex items-center justify-center text-gray-500"> {/* Adjusted to fill parent */}
             No Image Available
           </div>
         )}

--- a/src/app/pages/google-books/page.js
+++ b/src/app/pages/google-books/page.js
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
+import Image from 'next/image';
 
 export default function GoogleBooksPage() {
   const [books, setBooks] = useState([]);
@@ -168,13 +169,15 @@ export default function GoogleBooksPage() {
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6">
         {displayedBooks.map((book) => (
           <div key={book.id} className="bg-neutral-800 bg-opacity-50 rounded-lg shadow-lg hover:shadow-2xl transition-all duration-300 ease-in-out flex flex-col overflow-hidden border border-neutral-700 hover:border-[var(--accent-color-dark)]">
-            <Link href={`/pages/google-books/${book.id}`} className="flex flex-col flex-grow">
+            <Link href={`/pages/google-books/${book.id}`} className="flex flex-col flex-grow group"> {/* Added group class here */}
               <div className="relative w-full h-72 flex items-center justify-center bg-neutral-700 overflow-hidden">
                 {book.volumeInfo.imageLinks?.thumbnail ? (
-                  <img 
-                    src={book.volumeInfo.imageLinks.thumbnail} 
-                    alt={book.volumeInfo.title} 
-                    className="w-full h-full object-contain transition-transform duration-300 group-hover:scale-105" // group-hover might need parent with 'group'
+                  <Image
+                    src={book.volumeInfo.imageLinks.thumbnail}
+                    alt={book.volumeInfo.title}
+                    fill
+                    style={{ objectFit: "contain" }}
+                    className="transition-transform duration-300 group-hover:scale-105"
                   />
                 ) : (
                   <div className="w-full h-full flex items-center justify-center text-neutral-500 text-sm">


### PR DESCRIPTION
Replaced standard HTML `<img>` tags with the `next/image` component in the following files:
- src/app/pages/books/BookListClient.js
- src/app/pages/google-books/[id]/page.js
- src/app/pages/google-books/page.js

This change addresses the `no-img-element` warning and leverages Next.js image optimization features for improved performance.