### PR TITLE
Style: Add white box to details pages

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -67,6 +67,14 @@ body {
   --foreground: var(--text-color);
 }
 
+/* White box style for details pages */
+.details-box {
+  background-color: #ffffff; /* White background */
+  padding: 2rem; /* Adjust padding as needed */
+  border-radius: 0.5rem; /* Rounded corners */
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); /* Subtle shadow */
+  color: #333333; /* Dark text color for contrast */
+}
 
 /* Link styles for the home page */
 .home-link {

--- a/src/app/pages/books/[id]/page.js
+++ b/src/app/pages/books/[id]/page.js
@@ -46,10 +46,11 @@ export default async function BookDetailPage({ params }) {
   };
 
   return (
-    <div className="container mx-auto p-4 md:p-8 bg-[var(--background-color)] text-[var(--text-color)]">
-      <div className="md:flex md:space-x-8">
-        {/* Left Column: Cover Image */}
-        <div className="md:w-1/3 mb-6 md:mb-0">
+    <div className="container mx-auto p-4 md:p-8">
+      <div className="details-box">
+        <div className="md:flex md:space-x-8">
+          {/* Left Column: Cover Image */}
+          <div className="md:w-1/3 mb-6 md:mb-0">
           {book.largeCoverImageUrl && book.largeCoverImageUrl !== "NO_COVER_AVAILABLE" ? (
             <Image
               src={book.largeCoverImageUrl}
@@ -176,6 +177,7 @@ export default async function BookDetailPage({ params }) {
         <Link href="/pages/books" className="inline-block bg-[var(--accent-color)] hover:bg-[var(--hover-accent-color)] text-white font-semibold py-2 px-4 rounded shadow transition-colors">
           Back to Books List
         </Link>
+      </div>
       </div>
     </div>
   );

--- a/src/app/pages/shorts/[id]/page.js
+++ b/src/app/pages/shorts/[id]/page.js
@@ -20,9 +20,10 @@ export default async function ShortStoryDetailPage({ params }) {
 
   return (
     <div className="container mx-auto p-4">
-      <h1 className="text-3xl font-bold mb-4">{story.title}</h1>
-      <p className="mb-2"><strong>Year:</strong> {story.year}</p>
-      <p className="mb-2"><strong>Type:</strong> {story.type}</p>
+      <div className="details-box">
+        <h1 className="text-3xl font-bold mb-4">{story.title}</h1>
+        <p className="mb-2"><strong>Year:</strong> {story.year}</p>
+        <p className="mb-2"><strong>Type:</strong> {story.type}</p>
       <p className="mb-2"><strong>Originally Published In:</strong> {story.originallyPublishedIn || 'N/A'}</p>
       <p className="mb-2"><strong>Collected In:</strong> {story.collectedIn || 'N/A'}</p>
       {filteredNotes.length > 0 && (
@@ -39,6 +40,7 @@ export default async function ShortStoryDetailPage({ params }) {
       <Link href="/pages/shorts" className="mt-6 inline-block bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold py-2 px-4 rounded shadow">
         Back to Shorts List
       </Link>
+      </div>
     </div>
   );
 }

--- a/src/app/pages/villains/[id]/page.js
+++ b/src/app/pages/villains/[id]/page.js
@@ -19,9 +19,10 @@ export default async function VillainDetailPage({ params }) {
 
   return (
     <div className="container mx-auto p-4">
-      <h1 className="text-3xl font-bold mb-4">{villain.name ? villain.name : 'Villain Detail'}</h1>
-      <p className="mb-2"><b>ID:</b> {params.id}</p>
-      {villain.gender && <p className="mb-2"><b>Gender:</b> {villain.gender}</p>}
+      <div className="details-box">
+        <h1 className="text-3xl font-bold mb-4">{villain.name ? villain.name : 'Villain Detail'}</h1>
+        <p className="mb-2"><b>ID:</b> {params.id}</p>
+        {villain.gender && <p className="mb-2"><b>Gender:</b> {villain.gender}</p>}
       {villain.status && <p className="mb-2"><b>Status:</b> {villain.status}</p>}
       {villain.notes && villain.notes.length > 0 && (
         <div className="mb-2">
@@ -41,6 +42,7 @@ export default async function VillainDetailPage({ params }) {
       <Link href="/pages/villains" className="mt-6 inline-block bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold py-2 px-4 rounded shadow">
         Back to Villains List
       </Link>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
This commit introduces a new CSS class `.details-box` to display content within a white box on the details pages for Books, Shorts, and Villains.

- Added `.details-box` class to `src/app/globals.css` with white background, padding, rounded corners, and shadow.
- Applied the class to the main container in:
  - `src/app/pages/books/[id]/page.js`
  - `src/app/pages/shorts/[id]/page.js`
  - `src/app/pages/villains/[id]/page.js`