### PR TITLE
FEAT: Add placeholder images to villains pages

### DIFF
--- a/src/app/pages/villains/VillainListClient.js
+++ b/src/app/pages/villains/VillainListClient.js
@@ -3,6 +3,7 @@
 import React, { useState, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
+import Image from 'next/image'; // Import Next.js Image component
 
 /**
  * VillainListClient component for displaying and filtering a list of villains.
@@ -83,16 +84,43 @@ export default function VillainListClient({ initialVillains }) {
 
       {/* Villains List Display */}
       {/* Renders the list of filtered villains */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-         {filteredVillains.map(villain => (
-             <div key={villain.id} className="p-4 bg-[var(--background-color)] rounded-lg shadow border border-[var(--accent-color)] hover:border-[var(--hover-accent-color)] transition-colors">
-                 <h2 className="text-xl font-semibold text-[var(--accent-color)] hover:text-[var(--hover-accent-color)]">
-                     <Link href={`/pages/villains/${villain.id}`}>
-                         {villain.name}
-                     </Link>
-                 </h2>
-                 {/* Add any other brief details if desired, e.g., villain.status */}
-                 {villain.status && <p className="text-sm text-[var(--text-color)] opacity-75">Status: {villain.status}</p>}
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6"> {/* Responsive grid */}
+        {filteredVillains.map((villain, index) => (
+            <div key={villain.id} className="group bg-[var(--background-color)] rounded-lg shadow border border-[var(--accent-color)] hover:border-[var(--hover-accent-color)] transition-all duration-300 ease-in-out flex flex-col overflow-hidden h-full hover:shadow-lg"> {/* Added h-full for consistent height and hover effect, ADDED group CLASS */}
+                {/* Villain Image */}
+                <div className="relative w-full h-72 flex items-center justify-center bg-neutral-700 overflow-hidden rounded-t-lg">
+                  {villain.image_url ? (
+                    <Image
+                      src={villain.image_url}
+                      alt={`Image of ${villain.name}`}
+                      fill
+                      style={{ objectFit: "contain" }}
+                      className="transition-transform duration-300 group-hover:scale-105 rounded-t-lg"
+                      priority={index < 8} // Approximate priority with eager loading for first few images
+                    />
+                  ) : (
+                    <div
+                      className="w-full h-full flex items-center justify-center text-neutral-500 text-sm"
+                    >
+                      No image available
+                    </div>
+                  )}
+                </div>
+                {/* Villain Details */}
+                <div className="p-4 flex flex-col flex-grow"> {/* Added flex-grow to push content to bottom if needed */}
+                     <h2 className="text-lg font-semibold text-[var(--accent-color)] hover:text-[var(--hover-accent-color)] mb-1 truncate" title={villain.name}> {/* Truncate title */}
+                         <Link href={`/pages/villains/${villain.id}`}>
+                             {villain.name}
+                         </Link>
+                     </h2>
+                     {villain.status && <p className="text-xs text-gray-500 dark:text-gray-300 mb-1">Status: {villain.status}</p>}
+
+                     <div className="mt-auto pt-2"> {/* Pushes the link to the bottom */}
+                        <Link href={`/pages/villains/${villain.id}`} className="text-sm text-[var(--accent-color)] hover:text-[var(--hover-accent-color)] font-medium">
+                            View Details
+                        </Link>
+                     </div>
+                 </div>
              </div>
          ))}
      </div>

--- a/src/app/pages/villains/[id]/page.js
+++ b/src/app/pages/villains/[id]/page.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Link from 'next/link';
+import Image from 'next/image'; // Import Next.js Image component
 import Request from '@/app/components/request';
 import VillainBookAppearances from './VillainBookAppearances';
 
@@ -20,28 +21,47 @@ export default async function VillainDetailPage({ params }) {
   return (
     <div className="container mx-auto p-4">
       <div className="details-box">
+        {/* Image Placeholder */}
+        <div className="relative w-full h-72 flex items-center justify-center bg-neutral-700 overflow-hidden rounded-lg mb-4">
+          {villain.image_url ? (
+            <Image
+              src={villain.image_url}
+              alt={`Image of ${villain.name}`}
+              fill
+              style={{ objectFit: "contain" }}
+              className="rounded-lg"
+            />
+          ) : (
+            <div
+              className="w-full h-full flex items-center justify-center text-neutral-500 text-sm"
+            >
+              No image available
+            </div>
+          )}
+        </div>
+
         <h1 className="text-3xl font-bold mb-4">{villain.name ? villain.name : 'Villain Detail'}</h1>
         <p className="mb-2"><b>ID:</b> {params.id}</p>
         {villain.gender && <p className="mb-2"><b>Gender:</b> {villain.gender}</p>}
-      {villain.status && <p className="mb-2"><b>Status:</b> {villain.status}</p>}
-      {villain.notes && villain.notes.length > 0 && (
-        <div className="mb-2">
-          <p><b>Notes:</b></p>
-          <ul className="list-disc pl-5">
-            {villain.notes.map((note, index) => (
-              <li key={index} className="mb-1">{note}</li>
-            ))}
-          </ul>
-        </div>
-      )}
+        {villain.status && <p className="mb-2"><b>Status:</b> {villain.status}</p>}
+        {villain.notes && villain.notes.length > 0 && (
+          <div className="mb-2">
+            <p><b>Notes:</b></p>
+            <ul className="list-disc pl-5">
+              {villain.notes.map((note, index) => (
+                <li key={index} className="mb-1">{note}</li>
+              ))}
+            </ul>
+          </div>
+        )}
 
-      <h2 className="text-2xl font-semibold mb-3 mt-6">Book Appearances:</h2>
-      <VillainBookAppearances villainId={params.id} />
+        <h2 className="text-2xl font-semibold mb-3 mt-6">Book Appearances:</h2>
+        <VillainBookAppearances villainId={params.id} />
 
-      <br />
-      <Link href="/pages/villains" className="mt-6 inline-block bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold py-2 px-4 rounded shadow">
-        Back to Villains List
-      </Link>
+        <br />
+        <Link href="/pages/villains" className="mt-6 inline-block bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold py-2 px-4 rounded shadow">
+          Back to Villains List
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
Implemented placeholder images for the villains list and villain details pages.
- Replicated the styling and structure from the books page for consistency.
- Placeholder text is 'No image available'.
- Ensured Next.js Image component is used.
- Updated relevant client and server components for villains.