### PR TITLE
Fix: Adjust button and mobile menu colors for light theme

### DIFF
--- a/src/app/components/NavigationBar.js
+++ b/src/app/components/NavigationBar.js
@@ -45,24 +45,24 @@ const NavigationBar = () => {
         data-testid="nav-links-container"
         className={`${
           isMobileMenuOpen ? 'flex' : 'hidden'
-        } flex-col items-stretch space-y-2 mt-4 p-4 bg-gray-800 rounded-md shadow-lg md:bg-transparent md:shadow-none md:mt-0 md:flex md:flex-row md:items-center md:space-y-0 md:space-x-4 md:ml-auto w-full md:w-auto`}
+        } mobile-menu-bg flex-col items-stretch space-y-2 mt-4 p-4 rounded-md shadow-lg md:bg-transparent md:shadow-none md:mt-0 md:flex md:flex-row md:items-center md:space-y-0 md:space-x-4 md:ml-auto w-full md:w-auto`}
       >
-        <Link href="/" className={`text-xl font-extrabold py-2 px-4 rounded-md hover:bg-gray-700 ${pathname === '/' ? 'underline' : ''}`} onClick={handleLinkClick}>
+        <Link href="/" className={`text-xl font-extrabold py-2 px-4 rounded-md mobile-menu-link-hover ${pathname === '/' ? 'underline' : ''}`} onClick={handleLinkClick}>
           HOME
         </Link>
-        <Link href="/pages/books" className={`text-xl font-extrabold py-2 px-4 rounded-md hover:bg-gray-700 ${pathname === '/pages/books' ? 'underline' : ''}`} onClick={handleLinkClick}>
+        <Link href="/pages/books" className={`text-xl font-extrabold py-2 px-4 rounded-md mobile-menu-link-hover ${pathname === '/pages/books' ? 'underline' : ''}`} onClick={handleLinkClick}>
           BOOKS
         </Link>
-        <Link href="/pages/shorts" className={`text-xl font-extrabold py-2 px-4 rounded-md hover:bg-gray-700 ${pathname === '/pages/shorts' ? 'underline' : ''}`} onClick={handleLinkClick}>
+        <Link href="/pages/shorts" className={`text-xl font-extrabold py-2 px-4 rounded-md mobile-menu-link-hover ${pathname === '/pages/shorts' ? 'underline' : ''}`} onClick={handleLinkClick}>
           SHORTS
         </Link>
-        <Link href="/pages/villains" className={`text-xl font-extrabold py-2 px-4 rounded-md hover:bg-gray-700 ${pathname === '/pages/villains' ? 'underline' : ''}`} onClick={handleLinkClick}>
+        <Link href="/pages/villains" className={`text-xl font-extrabold py-2 px-4 rounded-md mobile-menu-link-hover ${pathname === '/pages/villains' ? 'underline' : ''}`} onClick={handleLinkClick}>
           VILLAINS
         </Link>
-        <Link href="/pages/google-books" className={`text-xl font-extrabold py-2 px-4 rounded-md hover:bg-gray-700 ${pathname === '/pages/google-books' ? 'underline' : ''}`} onClick={handleLinkClick}>
+        <Link href="/pages/google-books" className={`text-xl font-extrabold py-2 px-4 rounded-md mobile-menu-link-hover ${pathname === '/pages/google-books' ? 'underline' : ''}`} onClick={handleLinkClick}>
           GOOGLE BOOKS
         </Link>
-        <a href="https://stephenking.com" target="_blank" rel="noopener noreferrer" className="text-xl font-extrabold py-2 px-4 rounded-md hover:bg-gray-700" onClick={handleLinkClick}>
+        <a href="https://stephenking.com" target="_blank" rel="noopener noreferrer" className="text-xl font-extrabold py-2 px-4 rounded-md mobile-menu-link-hover" onClick={handleLinkClick}>
           STEPHENKING.COM <span className="text-sm opacity-75">(Official Site)</span>
         </a>
       </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -180,3 +180,22 @@ body::before {
 .shorts-list-container .short-item:nth-child(even) {
   background-color: var(--row-bg-even);
 }
+
+/* Mobile navigation menu styles */
+.mobile-menu-bg {
+  background-color: var(--background-color-dark); /* Default to dark theme background */
+}
+
+.mobile-menu-link-hover:hover {
+  background-color: var(--hover-accent-color-dark); /* Default to dark theme hover accent */
+}
+
+@media (prefers-color-scheme: light) {
+  .mobile-menu-bg {
+    background-color: var(--accent-color-light); /* Use light theme accent for menu background */
+  }
+
+  .mobile-menu-link-hover:hover {
+    background-color: var(--hover-accent-color-light); /* Use light theme hover accent for links */
+  }
+}


### PR DESCRIPTION
Ensures that buttons on the main page and the mobile navigation menu use lighter, theme-appropriate colors when the light theme is active.

- Modified `globals.css` to define new classes for mobile menu background and link hover states, using CSS variables for theme adaptability.
- Updated `NavigationBar.js` to use these new CSS classes, removing hardcoded dark background colors for the mobile menu.
- Confirmed that `home-link` styles (used for main page buttons/links) already correctly use theme variables.