### PR TITLE
Fix: Apply dark theme to details box

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -47,6 +47,11 @@ body {
   --row-bg-odd: var(--row-bg-odd-dark);
   --row-bg-even: var(--row-bg-even-dark);
 
+  /* Details box colors for dark theme */
+  --details-box-bg: var(--row-bg-even-dark);
+  --details-box-text: var(--text-color-dark);
+  --details-box-shadow: rgba(255, 255, 255, 0.05); /* Subtle light shadow for dark mode */
+
   color: var(--text-color);
   background: var(--background-color);
   font-family: 'GeistMonoVF', 'GeistVF', Arial, Helvetica, sans-serif; /* Prioritize Geist fonts */
@@ -67,6 +72,11 @@ body {
     --row-bg-odd: var(--row-bg-odd-light);
     --row-bg-even: var(--row-bg-even-light);
 
+    /* Details box colors for light theme */
+    --details-box-bg: #ffffff;
+    --details-box-text: #333333;
+    --details-box-shadow: rgba(0, 0, 0, 0.1);
+
     color: var(--text-color);
     background: var(--background-color);
   }
@@ -77,15 +87,20 @@ body {
 :root {
   --background: var(--background-color);
   --foreground: var(--text-color);
+
+  /* Details box specific variables - default to light theme values */
+  --details-box-bg: #ffffff;
+  --details-box-text: #333333;
+  --details-box-shadow: rgba(0, 0, 0, 0.1);
 }
 
 /* White box style for details pages */
 .details-box {
-  background-color: #ffffff; /* White background */
+  background-color: var(--details-box-bg);
   padding: 2rem; /* Adjust padding as needed */
   border-radius: 0.5rem; /* Rounded corners */
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); /* Subtle shadow */
-  color: #333333; /* Dark text color for contrast */
+  box-shadow: 0 4px 6px var(--details-box-shadow); /* Subtle shadow */
+  color: var(--details-box-text);
 }
 
 /* Link styles for the home page */


### PR DESCRIPTION
The .details-box element on various details pages (Books, Google Books, Villains, Shorts) retained a white background in dark mode.

This commit updates `src/app/globals.css` to use CSS variables for the background color, text color, and box shadow of the `.details-box` element. These variables are then set appropriately for both dark and light themes, ensuring the details box aligns with the 'eery&minimalistic' dark theme by using a darker background (`#111111`) and lighter text (`#c0c0c0`) in dark mode, while preserving the original appearance in light mode.