### PR TITLE
feat: Implement theme-aware page titles and adjust nav contrast

### DIFF
--- a/src/app/components/NavigationBar.js
+++ b/src/app/components/NavigationBar.js
@@ -20,7 +20,7 @@ const NavigationBar = () => {
       <div className="flex items-center justify-between md:flex-col md:items-start">
         <div className="text-2xl font-bold mb-0 md:mb-4">Stephen King Universe</div>
         <button
-          className="md:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white"
+           className="md:hidden p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-inset focus:ring-[var(--nav-link-focus-ring)]"
           onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
           aria-label="Toggle menu"
           aria-expanded={isMobileMenuOpen}
@@ -53,25 +53,25 @@ const NavigationBar = () => {
         } mobile-menu-bg flex-col items-stretch space-y-2 mt-4 p-4 rounded-md shadow-lg
            md:flex md:bg-transparent md:shadow-none md:mt-0 md:p-0 md:space-y-2 w-full`}
       >
-        <Link href="/" className={`text-lg py-2 px-4 rounded-md mobile-menu-link-hover md:hover:bg-gray-700 ${pathname === '/' ? 'underline' : ''}`} onClick={handleLinkClick}>
+        <Link href="/" className={`text-lg py-2 px-4 rounded-md mobile-menu-link-hover nav-link-desktop-hover ${pathname === '/' ? 'underline' : ''}`} onClick={handleLinkClick}>
           HOME
         </Link>
-        <Link href="/pages/books" className={`text-lg py-2 px-4 rounded-md mobile-menu-link-hover md:hover:bg-gray-700 ${pathname === '/pages/books' ? 'underline' : ''}`} onClick={handleLinkClick}>
+        <Link href="/pages/books" className={`text-lg py-2 px-4 rounded-md mobile-menu-link-hover nav-link-desktop-hover ${pathname === '/pages/books' ? 'underline' : ''}`} onClick={handleLinkClick}>
           BOOKS
         </Link>
-        <Link href="/pages/shorts" className={`text-lg py-2 px-4 rounded-md mobile-menu-link-hover md:hover:bg-gray-700 ${pathname === '/pages/shorts' ? 'underline' : ''}`} onClick={handleLinkClick}>
+        <Link href="/pages/shorts" className={`text-lg py-2 px-4 rounded-md mobile-menu-link-hover nav-link-desktop-hover ${pathname === '/pages/shorts' ? 'underline' : ''}`} onClick={handleLinkClick}>
           SHORTS
         </Link>
-        <Link href="/pages/villains" className={`text-lg py-2 px-4 rounded-md mobile-menu-link-hover md:hover:bg-gray-700 ${pathname === '/pages/villains' ? 'underline' : ''}`} onClick={handleLinkClick}>
+        <Link href="/pages/villains" className={`text-lg py-2 px-4 rounded-md mobile-menu-link-hover nav-link-desktop-hover ${pathname === '/pages/villains' ? 'underline' : ''}`} onClick={handleLinkClick}>
           VILLAINS
         </Link>
-        <Link href="/pages/google-books" className={`text-lg  py-2 px-4 rounded-md mobile-menu-link-hover md:hover:bg-gray-700 ${pathname === '/pages/google-books' ? 'underline' : ''}`} onClick={handleLinkClick}>
+        <Link href="/pages/google-books" className={`text-lg  py-2 px-4 rounded-md mobile-menu-link-hover nav-link-desktop-hover ${pathname === '/pages/google-books' ? 'underline' : ''}`} onClick={handleLinkClick}>
           GOOGLE BOOKS
         </Link>
-        <Link href="/pages/about-stephen-king" className={`text-lg py-2 px-4 rounded-md mobile-menu-link-hover md:hover:bg-gray-700 ${pathname === '/pages/about-stephen-king' ? 'underline' : ''}`} onClick={handleLinkClick}>
+        <Link href="/pages/about-stephen-king" className={`text-lg py-2 px-4 rounded-md mobile-menu-link-hover nav-link-desktop-hover ${pathname === '/pages/about-stephen-king' ? 'underline' : ''}`} onClick={handleLinkClick}>
           ABOUT STEPHEN KING
         </Link>
-        <a href="https://stephenking.com" target="_blank" rel="noopener noreferrer" className="text-lg py-2 px-4 rounded-md mobile-menu-link-hover md:hover:bg-gray-700" onClick={handleLinkClick}>
+        <a href="https://stephenking.com" target="_blank" rel="noopener noreferrer" className="text-lg py-2 px-4 rounded-md mobile-menu-link-hover nav-link-desktop-hover" onClick={handleLinkClick}>
           STEPHENKING.COM <span className="text-sm opacity-75">(Official Site)</span>
         </a>
       </div>

--- a/src/app/components/PageTitle.js
+++ b/src/app/components/PageTitle.js
@@ -30,8 +30,8 @@ const PageTitle = () => {
   // We'll use a consistent style for all layout titles for now.
   // If specific pages need their own unique title styling like the original Google Books page,
   // that title should be part of the page's content itself rather than this layout component.
-  // Applying consistent style for all titles, matching the "Google Books Explorer" style.
-  const titleStyle = "text-4xl md:text-5xl font-bold mb-8 text-center text-transparent bg-clip-text bg-gradient-to-r from-[var(--accent-color-dark)] via-[var(--hover-accent-color-dark)] to-[var(--accent-color-dark)] py-2 hidden md:block";
+  // Applying consistent style for all titles, using theme-aware CSS variables for the gradient.
+  const titleStyle = "text-4xl md:text-5xl font-bold mb-8 text-center text-transparent bg-clip-text bg-gradient-to-r from-[var(--title-gradient-from)] via-[var(--title-gradient-via)] to-[var(--title-gradient-to)] py-2 hidden md:block";
 
   // The Google Books Explorer page has its own title.
   // This component will render titles for other pages.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -31,6 +31,21 @@
   /* Alternating row colors for light theme */
   --row-bg-odd-light: var(--background-color-light); /* Same as main background */
   --row-bg-even-light: #ebebeb; /* Slightly darker than main background */
+
+  /* Page Title Gradient Colors */
+  --title-gradient-from-dark: var(--accent-color-dark);
+  --title-gradient-via-dark: var(--hover-accent-color-dark);
+  --title-gradient-to-dark: var(--accent-color-dark);
+
+  --title-gradient-from-light: var(--accent-color-light);
+  --title-gradient-via-light: var(--hover-accent-color-light);
+  --title-gradient-to-light: var(--accent-color-light);
+
+  /* Navigation Link Hover Background Colors */
+  --nav-link-hover-bg-dark: #374151; /* Corresponds to gray-700 */
+  --nav-link-hover-bg-light: #d1d5db; /* A lighter gray (gray-300) for less contrast but still eery */
+  --nav-link-focus-ring-dark: #ffffff;
+  --nav-link-focus-ring-light: #2563eb; /* A blue for visibility, similar to Tailwind's default focus ring */
 }
 
 /* Default to dark theme */
@@ -46,6 +61,15 @@ body {
   --map-marker-hover-stroke: var(--map-marker-hover-stroke-dark);
   --row-bg-odd: var(--row-bg-odd-dark);
   --row-bg-even: var(--row-bg-even-dark);
+
+  /* Page title gradient */
+  --title-gradient-from: var(--title-gradient-from-dark);
+  --title-gradient-via: var(--title-gradient-via-dark);
+  --title-gradient-to: var(--title-gradient-to-dark);
+
+  /* Navigation link hover */
+  --nav-link-hover-bg: var(--nav-link-hover-bg-dark);
+  --nav-link-focus-ring: var(--nav-link-focus-ring-dark);
 
   /* Details box colors for dark theme */
   --details-box-bg: var(--row-bg-even-dark);
@@ -71,6 +95,15 @@ body {
     --map-marker-hover-stroke: var(--map-marker-hover-stroke-light);
     --row-bg-odd: var(--row-bg-odd-light);
     --row-bg-even: var(--row-bg-even-light);
+
+    /* Page title gradient */
+    --title-gradient-from: var(--title-gradient-from-light);
+    --title-gradient-via: var(--title-gradient-via-light);
+    --title-gradient-to: var(--title-gradient-to-light);
+
+  /* Navigation link hover */
+  --nav-link-hover-bg: var(--nav-link-hover-bg-light);
+  --nav-link-focus-ring: var(--nav-link-focus-ring-light);
 
     /* Details box colors for light theme */
     --details-box-bg: #ffffff;
@@ -213,4 +246,9 @@ body::before {
   .mobile-menu-link-hover:hover {
     background-color: var(--hover-accent-color-light); /* Use light theme hover accent for links */
   }
+}
+
+/* Utility class for navigation link hover background */
+.nav-link-desktop-hover:hover {
+  background-color: var(--nav-link-hover-bg);
 }


### PR DESCRIPTION
- Added CSS variables for page title gradients, adapting to light/dark themes.
- Modified PageTitle.js to use these theme-aware gradient variables.
- Updated NavigationBar.js for better light theme aesthetics:
  - Desktop link hover now uses a theme-aware variable for reduced contrast on light theme (gray-300) while keeping dark theme hover (gray-700).
  - Mobile menu button focus ring is now theme-aware (white on dark, blue on light).
- Ensured all changes maintain the eery & minimalistic style.