### PR TITLE
feat: Implement advanced search for Google Books

### DIFF
--- a/src/app/pages/google-books/advanced-search/page.js
+++ b/src/app/pages/google-books/advanced-search/page.js
@@ -1,0 +1,63 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+
+export default function AdvancedSearchPage() {
+  const [searchTerm, setSearchTerm] = useState('');
+  const router = useRouter();
+
+  const handleSearch = (e) => {
+    e.preventDefault();
+    // Construct a query string that the Google Books page can parse
+    // We'll use `adv_searchTerm` to distinguish it from the regular search
+    const queryParams = new URLSearchParams();
+    if (searchTerm.trim()) {
+      queryParams.set('adv_searchTerm', searchTerm.trim());
+    }
+    // Potentially add more advanced search parameters here in the future
+
+    router.push(`/pages/google-books?${queryParams.toString()}`);
+  };
+
+  return (
+    <div className="min-h-screen bg-background text-foreground p-4 md:p-8">
+      <header className="mb-10">
+        <h1 className="text-4xl md:text-5xl font-bold mb-8 text-center text-transparent bg-clip-text bg-gradient-to-r from-[var(--accent-color-dark)] via-[var(--hover-accent-color-dark)] to-[var(--accent-color-dark)] py-2">
+          Advanced Search for Stephen King Books
+        </h1>
+      </header>
+
+      <main className="max-w-xl mx-auto">
+        <form onSubmit={handleSearch} className="space-y-6">
+          <div>
+            <label htmlFor="searchTerm" className="block text-sm font-medium text-neutral-300 mb-1">
+              Search Term
+            </label>
+            <input
+              type="text"
+              id="searchTerm"
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              placeholder="e.g., The Stand, IT, Carrie"
+              className="w-full p-3 bg-[var(--background-color-dark)] text-[var(--text-color-dark)] border border-[var(--shadow-color-dark)] rounded-md shadow-sm text-base focus:ring-[var(--accent-color-dark)] focus:border-[var(--accent-color-dark)] placeholder-gray-500"
+            />
+          </div>
+
+          <div className="flex items-center justify-end space-x-4">
+            <Link href="/pages/google-books" className="text-sm text-[var(--accent-color-dark)] hover:text-[var(--hover-accent-color-dark)]">
+              Cancel
+            </Link>
+            <button
+              type="submit"
+              className="px-6 py-2.5 bg-[var(--accent-color-dark)] text-white font-semibold rounded-md shadow-md hover:bg-[var(--hover-accent-color-dark)] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[var(--accent-color-dark)] focus:ring-offset-[var(--background-color-dark)]"
+            >
+              Search
+            </button>
+          </div>
+        </form>
+      </main>
+    </div>
+  );
+}

--- a/src/app/pages/google-books/page.js
+++ b/src/app/pages/google-books/page.js
@@ -22,22 +22,41 @@ export default function GoogleBooksPage() {
   const [totalItemsFromAPI, setTotalItemsFromAPI] = useState(0); // Total items from API for a given query
   const booksPerPage = 20; // Max results per API call
 
-  // State Initialization from sessionStorage (runs once on mount)
+  // State Initialization from sessionStorage and URL parameters (runs once on mount)
   useEffect(() => {
-    // Load debounced search query for API, and also set the input text to match
-    const savedSearchQuery = sessionStorage.getItem('googleBooks_searchQuery');
-    if (savedSearchQuery) {
-      const parsedQuery = JSON.parse(savedSearchQuery);
-      setSearchQuery(parsedQuery);
-      setSearchInputText(parsedQuery);
+    const params = new URLSearchParams(window.location.search);
+    const advancedSearchTerm = params.get('adv_searchTerm');
+
+    if (advancedSearchTerm) {
+      // If an advanced search term is present in the URL, use it
+      setSearchInputText(advancedSearchTerm);
+      setSearchQuery(advancedSearchTerm);
+      setCurrentPage(0); // Reset to first page for new search
+      // Clear the adv_searchTerm from URL to prevent re-triggering on refresh if not desired,
+      // and rely on sessionStorage for subsequent state persistence.
+      // Or, keep it if you want the URL to be the source of truth for this specific search.
+      // For this implementation, let's clear it and let sessionStorage take over.
+      const newUrl = window.location.pathname; // Get path without query params
+      window.history.replaceState({...window.history.state, as: newUrl, url: newUrl }, '', newUrl);
+
+    } else {
+      // Otherwise, load from sessionStorage as before
+      const savedSearchQuery = sessionStorage.getItem('googleBooks_searchQuery');
+      if (savedSearchQuery) {
+        const parsedQuery = JSON.parse(savedSearchQuery);
+        setSearchQuery(parsedQuery);
+        setSearchInputText(parsedQuery);
+      }
+
+      const savedCurrentPage = sessionStorage.getItem('googleBooks_currentPage');
+      if (savedCurrentPage) setCurrentPage(JSON.parse(savedCurrentPage));
     }
 
-    const savedCurrentPage = sessionStorage.getItem('googleBooks_currentPage');
-    if (savedCurrentPage) setCurrentPage(JSON.parse(savedCurrentPage));
-
+    // Language is independent of advanced search term, load from session
     const savedLanguage = sessionStorage.getItem('googleBooks_language');
     if (savedLanguage) setLanguage(JSON.parse(savedLanguage));
-  }, []);
+
+  }, []); // Empty dependency array means this runs once on mount
 
   const executeSearch = () => {
     setSearchQuery(searchInputText);
@@ -199,6 +218,11 @@ export default function GoogleBooksPage() {
                 {/* Add more languages as needed */}
               </select>
             </div>
+          </div>
+          <div className="text-center mt-3"> {/* Increased margin-top for better spacing */}
+            <Link href="/pages/google-books/advanced-search" className="inline-block px-4 py-2 text-sm font-medium text-[var(--accent-color-dark)] border border-[var(--accent-color-dark)] rounded-md hover:bg-[var(--accent-color-dark)] hover:text-white transition-colors duration-150 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[var(--accent-color-dark)] focus:ring-offset-[var(--background-color-dark)]">
+              Go to Advanced Search
+            </Link>
           </div>
         </div>
       </header>


### PR DESCRIPTION
This commit introduces an advanced search feature for Stephen King books on the Google Books page.

Key changes:
- Added a new page `/pages/google-books/advanced-search` with a form to input search terms.
- The advanced search page navigates back to the main Google Books page, passing the search term as a URL parameter (`adv_searchTerm`).
- The Google Books page (`/pages/google-books`) has been updated to:
  - Include a link to the new Advanced Search page.
  - Prioritize `adv_searchTerm` from the URL to populate the search query. The API call inherently searches for Stephen King books, so the advanced term is used for the title.
  - Clear the `adv_searchTerm` from the URL after processing, relying on sessionStorage for subsequent state persistence.
- Existing functionality for direct search and language filtering on the Google Books page remains intact.

The implementation ensures that users can perform a more targeted search for Stephen King's books and view the results on the familiar Google Books page interface.