### PR TITLE
Add invisible background text to home page

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -121,6 +121,26 @@ body {
   }
 }
 
+/* Added for home page background text */
+.home-background-text::before {
+  content: 'STEPHEN KING UNIVERSE: HOME';
+  position: fixed; /* Use fixed to ensure it stays in place even with scrolling */
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 8vw; /* Responsive font size, slightly reduced */
+  font-weight: bold;
+  color: rgba(128, 128, 128, 0.05); /* Very light gray with low opacity */
+  white-space: normal; /* Allow text to wrap */
+  line-height: 1.2; /* Adjust line height for wrapped text */
+  z-index: -1; /* Ensure it's behind all other content */
+  pointer-events: none; /* Make sure it doesn't interfere with mouse events */
+  text-align: center; /* Center the text */
+  overflow: hidden; /* Hide any part of the text that might overflow */
+  width: 90%; /* Reduce width slightly to give some padding from edges */
+  word-break: break-word; /* Break words if necessary to prevent overflow */
+}
+
 /* Update existing variables to use the new scheme or remove if redundant */
 /* These are used by Tailwind config */
 :root {

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -14,7 +14,7 @@ const pageLinks = [
 // Page component - Renders the main page with title and navigation links with summaries.
 export default function Page() {
   return (
-    <div className="flex flex-col items-center min-h-screen bg-transparent py-10 px-4">
+    <div className="flex flex-col items-center min-h-screen bg-transparent py-10 px-4 home-background-text">
       {/* Book Carousel */}
       <BookCarousel />
 


### PR DESCRIPTION
- Added 'STEPHEN KING UNIVERSE: HOME' as a large, faint, centered background text on the home page.
- Text is styled using CSS to be almost invisible and positioned behind all other content.
- Ensured text wraps and fits within the page boundaries.