### PR TITLE
Fix: Make search icon theme-aware

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -307,7 +307,7 @@ body::before {
 
 /* Styling for the search icon to ensure visibility */
 .search-icon {
-  stroke: var(--text-color); /* Default to text color, which is theme aware */
+  color: var(--text-color); /* Default to text color, which is theme aware. SVG uses stroke="currentColor" */
 }
 
 /* Override for search icon when inside the input field if needed, e.g. to ensure it's not borderless */

--- a/src/app/pages/books/BookListClient.js
+++ b/src/app/pages/books/BookListClient.js
@@ -232,7 +232,7 @@ export default function BookListClient({ initialBooks }) {
                     autoFocus // Automatically focus the search bar when it appears
                   />
                   <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                    <Image src={SearchIcon} alt="Search" width={20} height={20} />
+                    <Image src={SearchIcon} alt="Search" width={20} height={20} className="search-icon" />
                   </div>
                 </div>
               )}
@@ -243,7 +243,7 @@ export default function BookListClient({ initialBooks }) {
                 style={{ minWidth: '2.5rem', width: '2.5rem' }} // Fixed size for the icon button
                 aria-label={isSearchBarVisible ? "Close search bar" : "Open search bar"}
               >
-                <Image src={SearchIcon} alt="Search" width={20} height={20} />
+                <Image src={SearchIcon} alt="Search" width={20} height={20} className="search-icon" />
               </button>
             </div>
           </div>


### PR DESCRIPTION
Updated the search icon styling to ensure it appears black on light themes and white on dark themes across Books, Villains, and Shorts pages.

- Added `className="search-icon"` to the search icon components in `BookListClient.js`.
- Modified the `.search-icon` CSS rule in `globals.css` to use `color: var(--text-color);` which is inherited by the SVG's `stroke="currentColor"` attribute.