### PR TITLE
Fix: Ensure search icon color respects theme

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -307,7 +307,7 @@ body::before {
 
 /* Styling for the search icon to ensure visibility */
 .search-icon {
-  stroke: var(--text-color); /* Default to text color, which is theme aware */
+  color: var(--text-color); /* Default to text color, which is theme aware. SVG uses stroke="currentColor" */
 }
 
 /* Override for search icon when inside the input field if needed, e.g. to ensure it's not borderless */

--- a/src/app/pages/books/BookListClient.js
+++ b/src/app/pages/books/BookListClient.js
@@ -4,7 +4,6 @@ import React, { useState, useMemo, Suspense } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image'; // Import Next.js Image component
-import SearchIcon from '../../../../public/search-icon.svg'; // Import the search icon
 // import dynamic from 'next/dynamic'; // FilterPopup no longer dynamically imported
 
 // const FilterPopup = dynamic(() => import('./FilterPopup'), { // FilterPopup component removed
@@ -231,8 +230,11 @@ export default function BookListClient({ initialBooks }) {
                     onChange={(e) => setSearchTerm(e.target.value)}
                     autoFocus // Automatically focus the search bar when it appears
                   />
-                  <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                    <Image src={SearchIcon} alt="Search" width={20} height={20} />
+                  <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none text-[var(--text-color)]">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                      <circle cx="11" cy="11" r="8"></circle>
+                      <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                    </svg>
                   </div>
                 </div>
               )}
@@ -243,7 +245,10 @@ export default function BookListClient({ initialBooks }) {
                 style={{ minWidth: '2.5rem', width: '2.5rem' }} // Fixed size for the icon button
                 aria-label={isSearchBarVisible ? "Close search bar" : "Open search bar"}
               >
-                <Image src={SearchIcon} alt="Search" width={20} height={20} />
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <circle cx="11" cy="11" r="8"></circle>
+                  <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                </svg>
               </button>
             </div>
           </div>

--- a/src/app/pages/shorts/ShortListClient.js
+++ b/src/app/pages/shorts/ShortListClient.js
@@ -5,7 +5,6 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image'; // Import Next.js Image component
 import TypeFilterMenu from '@/app/components/TypeFilterMenu'; // Import the new component
-import SearchIcon from '../../../../public/search-icon.svg'; // Import the search icon
 
 /**
  * ShortListClient component for displaying and filtering a list of short stories.
@@ -132,8 +131,11 @@ export default function ShortListClient({ initialShorts }) {
                     onChange={(e) => setSearchTerm(e.target.value)}
                     autoFocus
                   />
-                  <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                    <Image src={SearchIcon} alt="Search" width={20} height={20} className="search-icon" />
+                  <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none text-[var(--text-color)]">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                      <circle cx="11" cy="11" r="8"></circle>
+                      <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                    </svg>
                   </div>
                 </div>
               )}
@@ -143,7 +145,10 @@ export default function ShortListClient({ initialShorts }) {
                 style={{ minWidth: '2.5rem', width: '2.5rem' }}
                 aria-label={isSearchBarVisible ? "Close search bar" : "Open search bar"}
               >
-                <Image src={SearchIcon} alt="Search" width={20} height={20} className="search-icon" />
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <circle cx="11" cy="11" r="8"></circle>
+                  <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                </svg>
               </button>
             </div>
           </div>

--- a/src/app/pages/villains/VillainListClient.js
+++ b/src/app/pages/villains/VillainListClient.js
@@ -5,7 +5,6 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image'; // Import Next.js Image component
 import StatusFilterMenu from '@/app/components/StatusFilterMenu'; // Import the new component
-import SearchIcon from '../../../../public/search-icon.svg'; // Import the search icon
 
 /**
  * VillainListClient component for displaying and filtering a list of villains.
@@ -100,8 +99,11 @@ export default function VillainListClient({ initialVillains }) {
                     onChange={(e) => setSearchTerm(e.target.value)}
                     autoFocus
                   />
-                  <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                    <Image src={SearchIcon} alt="Search" width={20} height={20} className="search-icon" />
+                  <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none text-[var(--text-color)]">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                      <circle cx="11" cy="11" r="8"></circle>
+                      <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                    </svg>
                   </div>
                 </div>
               )}
@@ -111,7 +113,10 @@ export default function VillainListClient({ initialVillains }) {
                 style={{ minWidth: '2.5rem', width: '2.5rem' }}
                 aria-label={isSearchBarVisible ? "Close search bar" : "Open search bar"}
               >
-                <Image src={SearchIcon} alt="Search" width={20} height={20} className="search-icon" />
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <circle cx="11" cy="11" r="8"></circle>
+                  <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                </svg>
               </button>
             </div>
           </div>


### PR DESCRIPTION
Replaced <Image> component usage for search icons with inline SVGs on Books, Villains, and Shorts pages. This ensures `stroke="currentColor"` in the SVGs correctly inherits the themed text color from parent elements, making the icons black on light theme and white on dark theme.

- Modified BookListClient.js, VillainListClient.js, and ShortListClient.js to use inline SVGs.
- Ensured parent elements of SVGs provide a themed color (e.g., using `text-[var(--text-color)]` or existing themed button classes).