### PR TITLE
Feat: Display Stephen King work adaptations on detail pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@tailwindcss/postcss": "^4.1.10",
+        "cheerio": "^1.1.0",
         "next": "^15.1.0",
+        "node-fetch": "^3.3.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "requests": "^0.3.0"
@@ -3823,6 +3825,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -4025,6 +4033,48 @@
         "node": ">=10"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.0.tgz",
+      "integrity": "sha512-+0hMx9eYhJvWbgpKV9hN7jg0JcwydpopZE4hgi+KvQtByZXPp04NiCWU0LzcAbP63abZckIHkTQaXVF52mX3xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.0",
+        "htmlparser2": "^10.0.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.10.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18.17"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/chownr": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
@@ -4223,6 +4273,34 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -4250,6 +4328,15 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -4462,6 +4549,73 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4511,6 +4665,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.18.2",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.2.tgz",
@@ -4528,7 +4695,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -5374,6 +5540,29 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -5466,6 +5655,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fsevents": {
@@ -5877,6 +6078,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -5919,7 +6139,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -8372,6 +8591,44 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/node-http-xhr": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/node-http-xhr/-/node-http-xhr-1.3.4.tgz",
@@ -8413,6 +8670,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/nwsapi": {
@@ -8701,10 +8970,34 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -9215,7 +9508,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -10302,6 +10594,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.11.0.tgz",
+      "integrity": "sha512-heTSIac3iLhsmZhUCjyS3JQEkZELateufzZuBaVM5RHXdSBMb1LPMQf5x+FH7qjsZYDP0ttAc3nnVpUB+wYbOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
@@ -10423,6 +10724,15 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -10437,7 +10747,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
       "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "0.6.3"
@@ -10450,7 +10759,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "fetch-open-data",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -11,7 +12,9 @@
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.1.10",
+    "cheerio": "^1.1.0",
     "next": "^15.1.0",
+    "node-fetch": "^3.3.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "requests": "^0.3.0"

--- a/scripts/scrapeAdaptations.js
+++ b/scripts/scrapeAdaptations.js
@@ -1,0 +1,273 @@
+import fetch from 'node-fetch';
+import * as cheerio from 'cheerio';
+import fs from 'fs';
+import path from 'path';
+
+const WIKIPEDIA_URL = 'https://en.wikipedia.org/wiki/List_of_adaptations_of_works_by_Stephen_King';
+const OUTPUT_PATH = path.join(process.cwd(), 'src', 'app', 'data', 'adaptations.json');
+
+// Ensure the directory exists
+const OUTPUT_DIR = path.dirname(OUTPUT_PATH);
+if (!fs.existsSync(OUTPUT_DIR)) {
+    fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+}
+
+// Helper to get text, prioritizing specific tags if available
+const getCellText = (cellCheerio, $) => {
+    if (!cellCheerio) return '';
+    // Try to get text from an italicized link first, then any link, then italics, then direct text
+    let text = cellCheerio.find('i a').text().trim();
+    if (text) return text;
+    text = cellCheerio.find('a').first().text().trim();
+    if (text) return text;
+    text = cellCheerio.find('i').first().text().trim();
+    if (text) return text;
+    return cellCheerio.text().trim();
+};
+
+// More specific text extraction for adaptation title (often in italics or a link within italics)
+const getAdaptationTitle = (cellCheerio, $) => {
+    if (!cellCheerio) return '';
+    // Check for <a> inside <i>
+    let title = cellCheerio.find('i').find('a').text().trim();
+    if (title) return title;
+    // Check for <i> directly
+    title = cellCheerio.find('i').text().trim();
+    if (title) return title;
+    // Fallback to any <a> tag
+    title = cellCheerio.find('a').text().trim();
+    if (title) return title;
+    // Final fallback to the whole cell's text if no specific tags found
+    return cellCheerio.text().trim();
+};
+
+
+const parseNotesAndOriginalWork = (notesCellCheerio, $, adaptationTitle) => {
+    const notesText = notesCellCheerio.text(); // Full text for keyword searching
+    let originalWorkTitle = '';
+    let originalWorkType = '';
+
+    // Pattern: "Based on the [type] "[Work Title]""
+    const explicitMatch = notesText.match(/Based on the (novel|short story|novella|series|story) "([^"]+)"/i);
+    if (explicitMatch && explicitMatch[2]) {
+        originalWorkTitle = explicitMatch[2].trim();
+        originalWorkType = explicitMatch[1].charAt(0).toUpperCase() + explicitMatch[1].slice(1);
+        if (originalWorkType === 'Story') originalWorkType = 'Short Story';
+    } else {
+        // Pattern: "Based on the [type] of the same name"
+        const sameNameMatch = notesText.match(/Based on the (novel|short story|novella) of the same name/i);
+        if (sameNameMatch) {
+            originalWorkTitle = adaptationTitle; // Assume adaptation title is the same as work title
+            originalWorkType = sameNameMatch[1].charAt(0).toUpperCase() + sameNameMatch[1].slice(1);
+        } else {
+            // Fallback: Look for any link in the notes cell as a potential work title
+            // This is less reliable and should be a last resort
+            const linkInNotes = notesCellCheerio.find('a').first();
+            if (linkInNotes.length > 0) {
+                originalWorkTitle = linkInNotes.text().trim();
+                // Try to infer type from surrounding text if title came from a generic link
+                if (notesText.toLowerCase().includes('novel')) originalWorkType = 'Novel';
+                else if (notesText.toLowerCase().includes('short story')) originalWorkType = 'Short Story';
+                else if (notesText.toLowerCase().includes('novella')) originalWorkType = 'Novella';
+                else if (notesText.toLowerCase().includes('series')) originalWorkType = 'Series';
+            }
+        }
+    }
+
+    // If originalWorkTitle is still blank, or suspicious (e.g. "Yes"), log warning
+    if (!originalWorkTitle || originalWorkTitle.toLowerCase() === 'yes' || originalWorkTitle.toLowerCase() === 'no') {
+        console.warn(`Suspicious/missing originalWorkTitle from notes: "${notesText}" for adaptation "${adaptationTitle}". Title found: "${originalWorkTitle}"`);
+        if (originalWorkTitle.toLowerCase() === 'yes' || originalWorkTitle.toLowerCase() === 'no') originalWorkTitle = ''; // Discard "Yes"/"No"
+    }
+
+    return { originalWorkTitle, originalWorkType };
+};
+
+
+const parseGenericAdaptationTable = (table, $, adaptationTypeCategory) => {
+    const adaptations = [];
+    const rows = $(table).find('tbody tr').toArray();
+    console.log(`Parsing table for category: ${adaptationTypeCategory}. Rows found: ${rows.length}`);
+
+    for (let i = 1; i < rows.length; i++) { // Start from 1 to skip header row
+        const columns = $(rows[i]).find('td').toArray();
+        if (columns.length < 3) { // Year, Title, Notes are minimum
+            console.warn(`Skipping row ${i} in ${adaptationTypeCategory}: Not enough columns (${columns.length})`);
+            continue;
+        }
+
+        const year = getCellText($(columns[0]), $);
+        const adaptationTitleCell = $(columns[1]);
+        const adaptationTitle = getAdaptationTitle(adaptationTitleCell, $);
+
+        // Notes column is typically 3rd (index 2) or 4th (index 3)
+        // For "Other film adaptations", it's usually index 2 (3rd column)
+        // For "Other TV adaptations", it's usually index 1 (2nd actual data column if year is 0, title 1, notes 2)
+        // Let's try to be more specific based on table structure.
+        // The "Other film adaptations" table has Year | Title | Director | Notes | Rotten Tomatoes
+        // The "Other TV adaptations" table has Year | Title | Notes | Distributor | Network | Rotten Tomatoes
+        let notesCell;
+        if (adaptationTypeCategory === 'Film') {
+            if (columns.length > 3) notesCell = $(columns[3]); // Director is columns[2]
+            else if (columns.length > 2) notesCell = $(columns[2]); // If director column is missing
+            else {
+                 console.warn(`Skipping row in Film: Not enough columns for Notes. Columns: ${columns.length}, Row content: ${$(rows[i]).text()}`);
+                 continue;
+            }
+        } else if (adaptationTypeCategory === 'Television') {
+             if (columns.length > 2) notesCell = $(columns[2]);
+             else {
+                console.warn(`Skipping row in TV: Not enough columns for Notes. Columns: ${columns.length}, Row content: ${$(rows[i]).text()}`);
+                continue;
+             }
+        } else {
+            console.warn(`Unknown adaptationTypeCategory: ${adaptationTypeCategory}`);
+            continue;
+        }
+
+        if (!notesCell || notesCell.length === 0) {
+            console.warn(`Skipping row in ${adaptationTypeCategory} (Title: ${adaptationTitle}): Notes cell not found or empty.`);
+            continue;
+        }
+
+        const { originalWorkTitle, originalWorkType } = parseNotesAndOriginalWork(notesCell, $, adaptationTitle);
+        let type = adaptationTypeCategory; // Default to category
+
+        const notesTextContent = notesCell.text().toLowerCase();
+        if (notesTextContent.includes('miniseries')) type = 'Miniseries';
+        else if (notesTextContent.includes('tv series') || notesTextContent.includes('television series')) type = 'TV Series';
+        else if (notesTextContent.includes('episode of the anthology series')) type = 'TV Episode (Anthology)';
+        // Retain Film or Television if not more specific.
+
+        if (adaptationTitle && year && originalWorkTitle && adaptationTitle.toLowerCase() !== 'yes' && adaptationTitle.toLowerCase() !== 'no') {
+            adaptations.push({
+                adaptationTitle,
+                year,
+                type,
+                originalWorkTitle,
+                originalWorkType,
+            });
+        } else {
+            console.warn(`Skipped adaptation due to missing critical info: Title='${adaptationTitle}', Year='${year}', OriginalWork='${originalWorkTitle}'`);
+        }
+    }
+    return adaptations;
+};
+
+const parseSKInvolvementTable = (table, $, adaptationTypeCategory) => {
+    const adaptations = [];
+    const rows = $(table).find('tbody tr').toArray();
+    console.log(`Parsing SK Involvement table for category: ${adaptationTypeCategory}. Rows found: ${rows.length}`);
+
+    for (let i = 1; i < rows.length; i++) { // Skip header
+        const columns = $(rows[i]).find('td').toArray();
+        // Year | Title | Writer | Actor | Role | Notes
+        if (columns.length < 6) {
+            console.warn(`Skipping row ${i} in SK Involvement ${adaptationTypeCategory}: Not enough columns (${columns.length})`);
+            continue;
+        }
+
+        const year = getCellText($(columns[0]), $);
+        const adaptationTitle = getAdaptationTitle($(columns[1]), $); // Title is in the second column
+        const notesCell = $(columns[5]); // Notes is the 6th column
+
+        const { originalWorkTitle, originalWorkType } = parseNotesAndOriginalWork(notesCell, $, adaptationTitle);
+        let type = adaptationTypeCategory; // Default to category
+
+        const notesTextContent = notesCell.text().toLowerCase();
+        if (notesTextContent.includes('miniseries')) type = 'Miniseries';
+        else if (notesTextContent.includes('tv series') || notesTextContent.includes('television series')) type = 'TV Series';
+         else if (adaptationTypeCategory === 'Film' && notesTextContent.includes('original work for the film')) {
+            // This is an original screenplay by King, but we are looking for adaptations *of his works*
+            // If originalWorkTitle is empty here, it means it's likely an original screenplay.
+            if (!originalWorkTitle) {
+                console.log(`Skipping original screenplay: ${adaptationTitle} (Film)`);
+                continue;
+            }
+        }
+
+
+        if (adaptationTitle && year && originalWorkTitle && adaptationTitle.toLowerCase() !== 'yes' && adaptationTitle.toLowerCase() !== 'no') {
+            adaptations.push({
+                adaptationTitle,
+                year,
+                type,
+                originalWorkTitle,
+                originalWorkType,
+            });
+        } else {
+             console.warn(`Skipped SK involvement adaptation due to missing info: Title='${adaptationTitle}', Year='${year}', OriginalWork='${originalWorkTitle}'`);
+        }
+    }
+    return adaptations;
+};
+
+
+async function scrapeAndSave() {
+    console.log('Fetching Wikipedia page...');
+    const response = await fetch(WIKIPEDIA_URL);
+    const html = await response.text();
+    const $ = cheerio.load(html);
+    console.log('Parsing content...');
+    let allAdaptations = [];
+
+    // Films
+    const filmsHeading = $('#Films').parent(); // h2#Films
+    // Table 1: "Adaptations with Stephen King's involvement" (Films)
+    const skFilmsTable = filmsHeading.nextAll('table.wikitable').eq(0);
+    if (skFilmsTable.length) {
+        console.log('Parsing "Adaptations with Stephen King\'s involvement (Films)" table...');
+        allAdaptations = allAdaptations.concat(parseSKInvolvementTable(skFilmsTable, $, 'Film'));
+    } else {
+        console.warn('Could not find "Adaptations with Stephen King\'s involvement (Films)" table.');
+    }
+
+    // Table 2: "Other film adaptations"
+    const otherFilmsTable = filmsHeading.nextAll('table.wikitable').eq(1);
+    if (otherFilmsTable.length) {
+        console.log('Parsing "Other film adaptations" table...');
+        allAdaptations = allAdaptations.concat(parseGenericAdaptationTable(otherFilmsTable, $, 'Film'));
+    } else {
+        console.warn('Could not find "Other film adaptations" table.');
+    }
+
+    // Television
+    const tvHeading = $('#Television').parent(); // h2#Television
+    // Table 1: "Adaptations with Stephen King's involvement" (TV)
+    const skTvTable = tvHeading.nextAll('table.wikitable').eq(0);
+    if (skTvTable.length) {
+        console.log('Parsing "Adaptations with Stephen King\'s involvement (TV)" table...');
+        allAdaptations = allAdaptations.concat(parseSKInvolvementTable(skTvTable, $, 'Television'));
+    } else {
+        console.warn('Could not find "Adaptations with Stephen King\'s involvement (TV)" table.');
+    }
+
+    // Table 2: "Other TV adaptations"
+    const otherTvTable = tvHeading.nextAll('table.wikitable').eq(1);
+    if (otherTvTable.length) {
+        console.log('Parsing "Other TV adaptations" table...');
+        allAdaptations = allAdaptations.concat(parseGenericAdaptationTable(otherTvTable, $, 'Television'));
+    } else {
+        console.warn('Could not find "Other TV adaptations" table.');
+    }
+
+    // Remove duplicates based on adaptationTitle, year, and originalWorkTitle (more robust)
+    const uniqueAdaptations = allAdaptations.filter((adaptation, index, self) =>
+        index === self.findIndex((a) => (
+            a.adaptationTitle === adaptation.adaptationTitle &&
+            a.year === adaptation.year &&
+            a.originalWorkTitle === adaptation.originalWorkTitle &&
+            a.type === adaptation.type // Added type to differentiate Film vs TV of same name/year
+        ))
+    );
+
+    console.log(`Found ${uniqueAdaptations.length} unique adaptations after filtering.`);
+
+    fs.writeFileSync(OUTPUT_PATH, JSON.stringify(uniqueAdaptations, null, 2));
+    console.log(`Adaptations data saved to ${OUTPUT_PATH}`);
+}
+
+scrapeAndSave().catch(error => {
+    console.error('Error during scraping or saving:', error);
+    process.exit(1);
+});

--- a/src/app/components/AdaptationList.js
+++ b/src/app/components/AdaptationList.js
@@ -1,0 +1,46 @@
+import React from 'react';
+
+const AdaptationList = ({ adaptations }) => {
+  if (!adaptations || adaptations.length === 0) {
+    return <p className="text-sm text-[var(--text-color)]">No known adaptations for this work.</p>;
+  }
+
+  // Enhanced normalization for matching, focusing on alphanumeric characters and case-insensitivity
+  const normalizeForMatch = (title) => {
+    if (!title) return '';
+    return title.toLowerCase().replace(/[^a-z0-9]/g, '');
+  };
+
+  // Group adaptations by their title to avoid listing the same adaptation multiple times
+  // if it somehow got duplicated with slightly different originalWorkTitle strings
+  // that normalized to the same thing.
+  const uniqueAdaptationsByTitle = adaptations.reduce((acc, current) => {
+    const normalizedAdaptationTitle = normalizeForMatch(current.adaptationTitle);
+    if (!acc[normalizedAdaptationTitle]) {
+      acc[normalizedAdaptationTitle] = current;
+    }
+    return acc;
+  }, {});
+
+  const finalAdaptations = Object.values(uniqueAdaptationsByTitle);
+
+  return (
+    <div className="mt-8 pt-6 border-t border-gray-300 dark:border-gray-600">
+      <h2 className="text-2xl font-semibold text-[var(--accent-color)] mb-3">Adaptations</h2>
+      <ul className="list-disc pl-5 space-y-2">
+        {finalAdaptations.map((adaptation, index) => (
+          <li key={`${adaptation.adaptationTitle}-${adaptation.year}-${index}`} className="text-sm">
+            <strong className="font-medium">{adaptation.adaptationTitle}</strong> ({adaptation.year})
+            <span className="text-gray-600 dark:text-gray-400 italic ml-2">- {adaptation.type}</span>
+            {/* Optional: Display original work title if it differs significantly or for clarity, though context implies it.
+                For now, keeping it concise as it's under the work's page.
+            <p className="text-xs text-gray-500 dark:text-gray-500 pl-2">Based on: {adaptation.originalWorkTitle}</p>
+            */}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default AdaptationList;

--- a/src/app/data/adaptations.json
+++ b/src/app/data/adaptations.json
@@ -1,0 +1,653 @@
+[
+  {
+    "adaptationTitle": "Creepshow",
+    "year": "1982",
+    "type": "Film",
+    "originalWorkTitle": "Weeds",
+    "originalWorkType": ""
+  },
+  {
+    "adaptationTitle": "Cat's Eye",
+    "year": "1985",
+    "type": "Film",
+    "originalWorkTitle": "Quitters, Inc.",
+    "originalWorkType": ""
+  },
+  {
+    "adaptationTitle": "Maximum Overdrive",
+    "year": "1986",
+    "type": "Film",
+    "originalWorkTitle": "Trucks",
+    "originalWorkType": "Short story"
+  },
+  {
+    "adaptationTitle": "Creepshow 2",
+    "year": "1987",
+    "type": "Film",
+    "originalWorkTitle": "The Raft",
+    "originalWorkType": "Short story"
+  },
+  {
+    "adaptationTitle": "Pet Sematary",
+    "year": "1989",
+    "type": "Film",
+    "originalWorkTitle": "Pet Sematary",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "Thinner",
+    "year": "1996",
+    "type": "Film",
+    "originalWorkTitle": "Thinner",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "A Good Marriage",
+    "year": "2014",
+    "type": "Film",
+    "originalWorkTitle": "A Good Marriage",
+    "originalWorkType": "Novella"
+  },
+  {
+    "adaptationTitle": "Cell",
+    "year": "2016",
+    "type": "Film",
+    "originalWorkTitle": "Cell",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "It Chapter Two",
+    "year": "2019",
+    "type": "Film",
+    "originalWorkTitle": "It Chapter Two",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "Carrie",
+    "year": "1976",
+    "type": "Film",
+    "originalWorkTitle": "Carrie",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "The Shining",
+    "year": "1980",
+    "type": "Film",
+    "originalWorkTitle": "The Shining",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "Cujo",
+    "year": "1983",
+    "type": "Film",
+    "originalWorkTitle": "Cujo",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "David Cronenberg",
+    "year": "The Dead Zone",
+    "type": "Film",
+    "originalWorkTitle": "[4]",
+    "originalWorkType": ""
+  },
+  {
+    "adaptationTitle": "John Carpenter",
+    "year": "Christine",
+    "type": "Film",
+    "originalWorkTitle": "[5]",
+    "originalWorkType": ""
+  },
+  {
+    "adaptationTitle": "Children of the Corn",
+    "year": "1984",
+    "type": "Film",
+    "originalWorkTitle": "Children of the Corn",
+    "originalWorkType": "Short story"
+  },
+  {
+    "adaptationTitle": "Mark L. Lester",
+    "year": "Firestarter",
+    "type": "Film",
+    "originalWorkTitle": "[7]",
+    "originalWorkType": ""
+  },
+  {
+    "adaptationTitle": "Stand by Me",
+    "year": "1986",
+    "type": "Film",
+    "originalWorkTitle": "The Body",
+    "originalWorkType": "Novella"
+  },
+  {
+    "adaptationTitle": "The Running Man",
+    "year": "1987",
+    "type": "Film",
+    "originalWorkTitle": "The Running Man",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "Tales from the Darkside: The Movie",
+    "year": "1990",
+    "type": "Film",
+    "originalWorkTitle": "The Cat from Hell",
+    "originalWorkType": "Short story"
+  },
+  {
+    "adaptationTitle": "Ralph S. Singleton",
+    "year": "Graveyard Shift",
+    "type": "Film",
+    "originalWorkTitle": "[11]",
+    "originalWorkType": ""
+  },
+  {
+    "adaptationTitle": "Rob Reiner",
+    "year": "Misery",
+    "type": "Film",
+    "originalWorkTitle": "[12]",
+    "originalWorkType": ""
+  },
+  {
+    "adaptationTitle": "The Dark Half",
+    "year": "1993",
+    "type": "Film",
+    "originalWorkTitle": "The Dark Half",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "Fraser Clarke Heston",
+    "year": "Needful Things",
+    "type": "Film",
+    "originalWorkTitle": "[14]",
+    "originalWorkType": ""
+  },
+  {
+    "adaptationTitle": "The Shawshank Redemption",
+    "year": "1994",
+    "type": "Film",
+    "originalWorkTitle": "Rita Hayworth and Shawshank Redemption",
+    "originalWorkType": "Novella"
+  },
+  {
+    "adaptationTitle": "The Mangler",
+    "year": "1995",
+    "type": "Film",
+    "originalWorkTitle": "The Mangler",
+    "originalWorkType": "Short story"
+  },
+  {
+    "adaptationTitle": "Taylor Hackford",
+    "year": "Dolores Claiborne",
+    "type": "Film",
+    "originalWorkTitle": "[17]",
+    "originalWorkType": ""
+  },
+  {
+    "adaptationTitle": "The Night Flier",
+    "year": "1997",
+    "type": "Film",
+    "originalWorkTitle": "The Night Flier",
+    "originalWorkType": "Short story"
+  },
+  {
+    "adaptationTitle": "Apt Pupil",
+    "year": "1998",
+    "type": "Film",
+    "originalWorkTitle": "Apt Pupil",
+    "originalWorkType": "Novella"
+  },
+  {
+    "adaptationTitle": "The Green Mile",
+    "year": "1999",
+    "type": "Film",
+    "originalWorkTitle": "The Green Mile",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "Hearts in Atlantis",
+    "year": "2001",
+    "type": "Film",
+    "originalWorkTitle": "Low Men in Yellow Coats",
+    "originalWorkType": "Novella"
+  },
+  {
+    "adaptationTitle": "Dreamcatcher",
+    "year": "2003",
+    "type": "Film",
+    "originalWorkTitle": "Dreamcatcher",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "Secret Window",
+    "year": "2004",
+    "type": "Film",
+    "originalWorkTitle": "Secret Window, Secret Garden",
+    "originalWorkType": "Novella"
+  },
+  {
+    "adaptationTitle": "Mick Garris",
+    "year": "Riding the Bullet",
+    "type": "Film",
+    "originalWorkTitle": "[24]",
+    "originalWorkType": ""
+  },
+  {
+    "adaptationTitle": "1408",
+    "year": "2007",
+    "type": "Film",
+    "originalWorkTitle": "1408",
+    "originalWorkType": "Short story"
+  },
+  {
+    "adaptationTitle": "Anurag Kashyap",
+    "year": "No Smoking",
+    "type": "Film",
+    "originalWorkTitle": "[26]",
+    "originalWorkType": ""
+  },
+  {
+    "adaptationTitle": "Frank Darabont",
+    "year": "The Mist",
+    "type": "Film",
+    "originalWorkTitle": "[27]",
+    "originalWorkType": ""
+  },
+  {
+    "adaptationTitle": "Dolan's Cadillac",
+    "year": "2009",
+    "type": "Film",
+    "originalWorkTitle": "Dolan's Cadillac",
+    "originalWorkType": "Novella"
+  },
+  {
+    "adaptationTitle": "Carrie",
+    "year": "2013",
+    "type": "Film",
+    "originalWorkTitle": "Carrie",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "Mercy",
+    "year": "2014",
+    "type": "Film",
+    "originalWorkTitle": "Gramma",
+    "originalWorkType": "Short story"
+  },
+  {
+    "adaptationTitle": "The Dark Tower",
+    "year": "2017",
+    "type": "Film",
+    "originalWorkTitle": "Based on the series of the same name",
+    "originalWorkType": "Series"
+  },
+  {
+    "adaptationTitle": "Andy Muschietti",
+    "year": "It",
+    "type": "Film",
+    "originalWorkTitle": "[32]",
+    "originalWorkType": ""
+  },
+  {
+    "adaptationTitle": "Mike Flanagan",
+    "year": "Gerald's Game",
+    "type": "Film",
+    "originalWorkTitle": "[33]",
+    "originalWorkType": ""
+  },
+  {
+    "adaptationTitle": "Zak Hilditch",
+    "year": "1922",
+    "type": "Film",
+    "originalWorkTitle": "[34]",
+    "originalWorkType": ""
+  },
+  {
+    "adaptationTitle": "Pet Sematary",
+    "year": "2019",
+    "type": "Film",
+    "originalWorkTitle": "Pet Sematary",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "Andy Muschietti",
+    "year": "It Chapter Two",
+    "type": "Film",
+    "originalWorkTitle": "[36]",
+    "originalWorkType": ""
+  },
+  {
+    "adaptationTitle": "Vincenzo Natali",
+    "year": "In the Tall Grass",
+    "type": "Film",
+    "originalWorkTitle": "[37]",
+    "originalWorkType": ""
+  },
+  {
+    "adaptationTitle": "Mike Flanagan",
+    "year": "Doctor Sleep",
+    "type": "Film",
+    "originalWorkTitle": "[38]",
+    "originalWorkType": ""
+  },
+  {
+    "adaptationTitle": "Children of the Corn",
+    "year": "2020",
+    "type": "Film",
+    "originalWorkTitle": "Children of the Corn",
+    "originalWorkType": "Short story"
+  },
+  {
+    "adaptationTitle": "Firestarter",
+    "year": "2022",
+    "type": "Film",
+    "originalWorkTitle": "Firestarter",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "John Lee Hancock",
+    "year": "Mr. Harrigan's Phone",
+    "type": "Film",
+    "originalWorkTitle": "[41]",
+    "originalWorkType": ""
+  },
+  {
+    "adaptationTitle": "The Boogeyman",
+    "year": "2023",
+    "type": "Film",
+    "originalWorkTitle": "The Boogeyman",
+    "originalWorkType": "Short story"
+  },
+  {
+    "adaptationTitle": "The Life of Chuck",
+    "year": "2024",
+    "type": "Film",
+    "originalWorkTitle": "The Life of Chuck",
+    "originalWorkType": "Novella"
+  },
+  {
+    "adaptationTitle": "Gary Dauberman",
+    "year": "'Salem's Lot",
+    "type": "Film",
+    "originalWorkTitle": "[44]",
+    "originalWorkType": ""
+  },
+  {
+    "adaptationTitle": "The Monkey",
+    "year": "2025",
+    "type": "Film",
+    "originalWorkTitle": "The Monkey",
+    "originalWorkType": "Short story"
+  },
+  {
+    "adaptationTitle": "The Long Walk",
+    "year": "2025",
+    "type": "Film",
+    "originalWorkTitle": "The Long Walk",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "Edgar Wright",
+    "year": "The Running Man",
+    "type": "Film",
+    "originalWorkTitle": "Edgar Wright",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "Billy Summers",
+    "year": "TBA",
+    "type": "Film",
+    "originalWorkTitle": "Billy Summers",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "The Stand",
+    "year": "1994",
+    "type": "Television",
+    "originalWorkTitle": "The Stand",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "The Langoliers",
+    "year": "1995",
+    "type": "Television",
+    "originalWorkTitle": "Four Past Midnight",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "The Shining",
+    "year": "1997",
+    "type": "Television",
+    "originalWorkTitle": "The Shining",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "Desperation",
+    "year": "2006",
+    "type": "Television",
+    "originalWorkTitle": "Desperation",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "Heads Will Roll",
+    "year": "2014",
+    "type": "TV Series",
+    "originalWorkTitle": "Heads Will Roll",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "People in the Rain",
+    "year": "2017",
+    "type": "TV Series",
+    "originalWorkTitle": "People in the Rain",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "The House of the Dead",
+    "year": "2021",
+    "type": "Miniseries",
+    "originalWorkTitle": "The House of the Dead",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "Salem's Lot",
+    "year": "1979",
+    "type": "Television",
+    "originalWorkTitle": "Salem's Lot",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "The Word Processor of the Gods",
+    "year": "1984",
+    "type": "TV Episode (Anthology)",
+    "originalWorkTitle": "The Word Processor of the Gods",
+    "originalWorkType": "Short story"
+  },
+  {
+    "adaptationTitle": "Gramma",
+    "year": "1986",
+    "type": "TV Episode (Anthology)",
+    "originalWorkTitle": "Gramma",
+    "originalWorkType": "Short story"
+  },
+  {
+    "adaptationTitle": "It",
+    "year": "1990",
+    "type": "Television",
+    "originalWorkTitle": "It",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "The Moving Finger",
+    "year": "1991",
+    "type": "TV Episode (Anthology)",
+    "originalWorkTitle": "The Moving Finger",
+    "originalWorkType": "Short story"
+  },
+  {
+    "adaptationTitle": "The Tommyknockers",
+    "year": "1993",
+    "type": "Television",
+    "originalWorkTitle": "The Tommyknockers",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "Trucks",
+    "year": "1997",
+    "type": "Television",
+    "originalWorkTitle": "Trucks",
+    "originalWorkType": "Short story"
+  },
+  {
+    "adaptationTitle": "Chattery Teeth",
+    "year": "Quicksilver Highway",
+    "type": "Television",
+    "originalWorkTitle": "20th Television",
+    "originalWorkType": ""
+  },
+  {
+    "adaptationTitle": "The Outer Limits",
+    "year": "The Revelations of 'Becka Paulson",
+    "type": "Television",
+    "originalWorkTitle": "MGM Television",
+    "originalWorkType": ""
+  },
+  {
+    "adaptationTitle": "Woh",
+    "year": "1998",
+    "type": "Television",
+    "originalWorkTitle": "It",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "Carrie",
+    "year": "2002",
+    "type": "Television",
+    "originalWorkTitle": "Carrie",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "The Dead Zone",
+    "year": "2002–2007",
+    "type": "Television",
+    "originalWorkTitle": "The Dead Zone",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "Salem's Lot",
+    "year": "2004",
+    "type": "Television",
+    "originalWorkTitle": "Salem's Lot",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "Nightmares & Dreamscapes",
+    "year": "2006",
+    "type": "Television",
+    "originalWorkTitle": "Nightmares & Dreamscapes",
+    "originalWorkType": ""
+  },
+  {
+    "adaptationTitle": "Children of the Corn",
+    "year": "2009",
+    "type": "Television",
+    "originalWorkTitle": "Children of the Corn",
+    "originalWorkType": "Short story"
+  },
+  {
+    "adaptationTitle": "Haven",
+    "year": "2010–2015",
+    "type": "Television",
+    "originalWorkTitle": "The Colorado Kid",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "Bag of Bones",
+    "year": "2011",
+    "type": "Television",
+    "originalWorkTitle": "Bag of Bones",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "Under the Dome",
+    "year": "2013–2015",
+    "type": "Television",
+    "originalWorkTitle": "Under the Dome",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "Big Driver",
+    "year": "2014",
+    "type": "Television",
+    "originalWorkTitle": "Big Driver",
+    "originalWorkType": "Novella"
+  },
+  {
+    "adaptationTitle": "11.22.63",
+    "year": "2016",
+    "type": "Television",
+    "originalWorkTitle": "11.22.63",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "The Mist",
+    "year": "2017",
+    "type": "Television",
+    "originalWorkTitle": "The Mist",
+    "originalWorkType": "Novella"
+  },
+  {
+    "adaptationTitle": "Mr. Mercedes",
+    "year": "2017–2019",
+    "type": "Television",
+    "originalWorkTitle": "Mr. Mercedes",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "Creepshow",
+    "year": "2019, 2020",
+    "type": "Television",
+    "originalWorkTitle": "Gray Matter",
+    "originalWorkType": ""
+  },
+  {
+    "adaptationTitle": "The Outsider",
+    "year": "2020",
+    "type": "Television",
+    "originalWorkTitle": "The Outsider",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "The Stand",
+    "year": "2020–2021",
+    "type": "Television",
+    "originalWorkTitle": "The Stand",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "Chapelwaite",
+    "year": "2021",
+    "type": "Television",
+    "originalWorkTitle": "Jerusalem's Lot",
+    "originalWorkType": "Short story"
+  },
+  {
+    "adaptationTitle": "The Institute",
+    "year": "2025",
+    "type": "Television",
+    "originalWorkTitle": "The Institute",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "Carrie",
+    "year": "TBA",
+    "type": "Television",
+    "originalWorkTitle": "Carrie",
+    "originalWorkType": "Novel"
+  },
+  {
+    "adaptationTitle": "Fairy Tale",
+    "year": "TBA",
+    "type": "Television",
+    "originalWorkTitle": "Fairy Tale",
+    "originalWorkType": "Novel"
+  }
+]

--- a/src/app/pages/books/[id]/page.js
+++ b/src/app/pages/books/[id]/page.js
@@ -35,6 +35,21 @@ export default async function BookDetailPage({ params }) {
   const book = bookData.data;
   const filteredNotes = book.Notes ? book.Notes.filter(note => note.trim() !== '') : [];
 
+import AdaptationList from '@/app/components/AdaptationList';
+import allAdaptationsData from '@/app/data/adaptations.json'; // Import the scraped data
+
+// Helper function to normalize title for matching
+const normalizeTitleForMatch = (title) => {
+  if (!title) return '';
+  // More robust normalization: lowercase, remove articles, remove punctuation, and whitespace
+  return title.toLowerCase()
+    .replace(/\b(the|a|an)\b/g, '') // remove articles
+    .replace(/[^\w\s]/gi, '')    // remove punctuation
+    .replace(/\s+/g, '')         // remove all whitespace
+    .trim();
+};
+
+
   // Helper function to render book details
   const renderDetail = (label, value) => {
     if (!value) return null;
@@ -178,7 +193,18 @@ export default async function BookDetailPage({ params }) {
         </div>
       )}
 
-      {/* The empty div that was here was removed as it caused a syntax error. */}
+      {/* Adaptations Section */}
+      <AdaptationList adaptations={
+        allAdaptationsData.filter(adaptation => {
+          const normBookTitle = normalizeTitleForMatch(book.Title);
+          const normOriginalWorkTitle = normalizeTitleForMatch(adaptation.originalWorkTitle);
+
+          // Direct match or if originalWorkTitle is "same as adaptation" and adaptation title matches book title
+          return normOriginalWorkTitle === normBookTitle ||
+                 (adaptation.originalWorkTitle === adaptation.adaptationTitle && normalizeTitleForMatch(adaptation.adaptationTitle) === normBookTitle);
+        })
+      } />
+
       </div> {/* This closes details-box */}
     </div>
   );


### PR DESCRIPTION
- Added a script to scrape adaptation data (film and TV) from Wikipedia.
- Stores scraped data in `src/app/data/adaptations.json`.
- Created an `AdaptationList` component to display adaptations.
- Integrated this component into book and short story detail pages.
- Detail pages now filter and show relevant adaptations for the viewed work.
- Includes title normalization for matching works to their adaptations.