### PR TITLE
Move StephenKing.com link from navbar to Kinghraphy page

### DIFF
--- a/src/app/components/NavigationBar.js
+++ b/src/app/components/NavigationBar.js
@@ -71,9 +71,6 @@ const NavigationBar = () => {
         <Link href="/pages/about-stephen-king" className={`text-sm lg:text-base font-bold py-2 px-3 rounded-md mobile-menu-link-hover nav-link-desktop-hover ${pathname === '/pages/about-stephen-king' ? 'underline' : ''}`} onClick={handleLinkClick}>
           KINGGRAPHY
         </Link>
-        <a href="https://stephenking.com" target="_blank" rel="noopener noreferrer" className="text-sm lg:text-base font-bold py-2 px-3 rounded-md mobile-menu-link-hover nav-link-desktop-hover" onClick={handleLinkClick}>
-          STEPHENKING.COM <span className="text-xs lg:text-sm opacity-75">(Official Site)</span>
-        </a>
       </div>
     </nav>
   );

--- a/src/app/pages/about-stephen-king/page.js
+++ b/src/app/pages/about-stephen-king/page.js
@@ -53,7 +53,18 @@ const AboutStephenKing = () => {
           </a>
           .
         </p>
-        
+        <p className="text-md mb-2">
+          Visit the official{' '}
+          <a
+            href="https://stephenking.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-500 hover:underline"
+          >
+            StephenKing.com
+          </a>
+          .
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
- Removed the link to the official Stephen King website from the main navigation bar.
- Added the link to the bottom of the 'Kinghraphy' (About Stephen King) page.