### PR TITLE
Fix: Apply consistent layout to Adapted Works page

### DIFF
--- a/src/app/pages/adapted-works/page.js
+++ b/src/app/pages/adapted-works/page.js
@@ -6,7 +6,7 @@ export default async function AdaptedWorksPage() {
   const adaptations = adaptationsDataJson; // Already an array
 
   return (
-    <div className="container mx-auto px-4 py-8 text-[var(--text-color)]">
+    <div className="container mx-auto px-4 py-8 text-[var(--text-color)] max-w-5xl">
       <PageTitle title="Adapted Works" />
 
       <div


### PR DESCRIPTION
Ensures the 'Adapted Works' page uses the same layout as other pages by adding the 'max-w-5xl' class to the main container. The title 'Adapted Works' is correctly displayed at the top with consistent spacing.