### PR TITLE
feat: Add reusable list/grid view components

### DIFF
--- a/src/app/components/ContentDisplay.js
+++ b/src/app/components/ContentDisplay.js
@@ -1,0 +1,34 @@
+// src/app/components/ContentDisplay.js
+import ListItem from './ListItem';
+import ImageItem from './ImageItem';
+
+const ContentDisplay = ({ items, view = 'list' }) => { // Default to 'list' view
+  if (!items || items.length === 0) {
+    return <p className="text-gray-500 dark:text-gray-400 text-center py-8">No items to display.</p>;
+  }
+
+  if (view === 'list') {
+    return (
+      <div className="space-y-4">
+        {items.map((item) => (
+          <ListItem key={item.id || item.title} item={item} />
+        ))}
+      </div>
+    );
+  }
+
+  if (view === 'grid') {
+    return (
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4 md:gap-6">
+        {items.map((item) => (
+          <ImageItem key={item.id || item.title} item={item} />
+        ))}
+      </div>
+    );
+  }
+
+  // Fallback for an unknown view type, though ideally this shouldn't be reached
+  return <p className="text-red-500">Unknown view type selected.</p>;
+};
+
+export default ContentDisplay;

--- a/src/app/components/ImageItem.js
+++ b/src/app/components/ImageItem.js
@@ -1,0 +1,44 @@
+// src/app/components/ImageItem.js
+import Image from 'next/image'; // Using next/image for optimization
+
+const ImageItem = ({ item }) => {
+  const { title, imageUrl, linkUrl } = item;
+
+  const content = (
+    <div className="group relative aspect-[3/4] w-full bg-gray-100 dark:bg-gray-800 rounded-lg overflow-hidden shadow-md hover:shadow-xl transition-shadow duration-300">
+      {imageUrl ? (
+        <Image
+          src={imageUrl}
+          alt={title || 'Item image'}
+          layout="fill"
+          objectFit="cover"
+          className="bg-gray-200 dark:bg-gray-700 transition-transform duration-300 group-hover:scale-105"
+        />
+      ) : (
+        <div className="w-full h-full flex items-center justify-center bg-gray-200 dark:bg-gray-700">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-12 h-12 text-gray-400 dark:text-gray-500">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" /> {/* Simple X as placeholder */}
+          </svg>
+        </div>
+      )}
+      <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+      <div className="absolute bottom-0 left-0 right-0 p-4">
+        <h3 className="text-base font-semibold text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300 delay-100 transform translate-y-4 group-hover:translate-y-0">
+          {title || 'Untitled Item'}
+        </h3>
+      </div>
+    </div>
+  );
+
+  if (linkUrl) {
+    return (
+      <a href={linkUrl} target="_blank" rel="noopener noreferrer" className="block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 rounded-lg">
+        {content}
+      </a>
+    );
+  }
+
+  return content;
+};
+
+export default ImageItem;

--- a/src/app/components/ListItem.js
+++ b/src/app/components/ListItem.js
@@ -1,0 +1,45 @@
+// src/app/components/ListItem.js
+import Image from 'next/image'; // Using next/image for optimization
+
+const ListItem = ({ item }) => {
+  const { title, description, imageUrl, linkUrl } = item;
+
+  const content = (
+    <div className="flex items-center space-x-4 p-4 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors duration-150">
+      {imageUrl && (
+        <div className="flex-shrink-0 w-20 h-20 md:w-24 md:h-24 relative rounded overflow-hidden">
+          <Image
+            src={imageUrl}
+            alt={title || 'Item image'}
+            layout="fill"
+            objectFit="cover"
+            className="bg-gray-200 dark:bg-gray-700" // Placeholder background
+          />
+        </div>
+      )}
+      {!imageUrl && (
+         <div className="flex-shrink-0 w-20 h-20 md:w-24 md:h-24 bg-gray-200 dark:bg-gray-700 rounded flex items-center justify-center text-gray-400 dark:text-gray-500">
+           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-8 h-8">
+             <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" /> {/* Simple X as placeholder */}
+           </svg>
+         </div>
+      )}
+      <div className="flex-grow">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">{title || 'Untitled Item'}</h3>
+        {description && <p className="text-sm text-gray-600 dark:text-gray-300 line-clamp-2">{description}</p>}
+      </div>
+    </div>
+  );
+
+  if (linkUrl) {
+    return (
+      <a href={linkUrl} target="_blank" rel="noopener noreferrer" className="block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 rounded-lg">
+        {content}
+      </a>
+    );
+  }
+
+  return content;
+};
+
+export default ListItem;

--- a/src/app/components/ViewSwitcher.js
+++ b/src/app/components/ViewSwitcher.js
@@ -1,0 +1,33 @@
+// src/app/components/ViewSwitcher.js
+import ListViewIcon from './icons/ListViewIcon';
+import GridViewIcon from './icons/GridViewIcon';
+
+const ViewSwitcher = ({ currentView, onViewChange }) => {
+  const commonButtonClasses = "p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500";
+  const activeButtonClasses = "bg-indigo-100 text-indigo-700 dark:bg-indigo-700 dark:text-indigo-100";
+  const inactiveButtonClasses = "text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200";
+  const iconClasses = "w-6 h-6";
+
+  return (
+    <div className="flex space-x-2">
+      <button
+        onClick={() => onViewChange('list')}
+        aria-label="Switch to list view"
+        title="List View"
+        className={`${commonButtonClasses} ${currentView === 'list' ? activeButtonClasses : inactiveButtonClasses}`}
+      >
+        <ListViewIcon className={iconClasses} />
+      </button>
+      <button
+        onClick={() => onViewChange('grid')}
+        aria-label="Switch to grid view"
+        title="Grid View"
+        className={`${commonButtonClasses} ${currentView === 'grid' ? activeButtonClasses : inactiveButtonClasses}`}
+      >
+        <GridViewIcon className={iconClasses} />
+      </button>
+    </div>
+  );
+};
+
+export default ViewSwitcher;

--- a/src/app/components/icons/GridViewIcon.js
+++ b/src/app/components/icons/GridViewIcon.js
@@ -1,0 +1,20 @@
+// src/app/components/icons/GridViewIcon.js
+const GridViewIcon = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    aria-hidden="true"
+    {...props} // Pass through any other props like className, width, height
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25A2.25 2.25 0 0 1 13.5 18v-2.25Z"
+    />
+  </svg>
+);
+
+export default GridViewIcon;

--- a/src/app/components/icons/ListViewIcon.js
+++ b/src/app/components/icons/ListViewIcon.js
@@ -1,0 +1,20 @@
+// src/app/components/icons/ListViewIcon.js
+const ListViewIcon = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    aria-hidden="true"
+    {...props} // Pass through any other props like className, width, height
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M8.25 6.75h12M8.25 12h12m-12 5.25h12M3.75 6.75h.007v.008H3.75V6.75Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0ZM3.75 12h.007v.008H3.75V12Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm-.375 5.25h.007v.008H3.75v-.008Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z"
+    />
+  </svg>
+);
+
+export default ListViewIcon;

--- a/src/app/pages/books/BookListClient.js
+++ b/src/app/pages/books/BookListClient.js
@@ -3,8 +3,11 @@
 import React, { useState, useMemo, Suspense } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import Image from 'next/image'; // Import Next.js Image component
-import SearchAndSortControls from '@/app/components/SearchAndSortControls'; // Import the new component
+// import Image from 'next/image'; // No longer directly used here, ContentDisplay handles images
+import SearchAndSortControls from '@/app/components/SearchAndSortControls';
+import ViewSwitcher from '@/app/components/ViewSwitcher'; // Added
+import ContentDisplay from '@/app/components/ContentDisplay'; // Added
+
 
 // const FilterPopup = dynamic(() => import('./FilterPopup'), { // FilterPopup component removed
 //   suspense: true,
@@ -21,12 +24,11 @@ export default function BookListClient({ initialBooks }) {
    const [searchTerm, setSearchTerm] = useState('');
    // New sortConfig state for SearchAndSortControls
    const [sortConfig, setSortConfig] = useState({ key: 'Title', direction: 'ascending' });
-   // const [isSearchBarVisible, setIsSearchBarVisible] = useState(false); // Will be handled by SearchAndSortControls
   const [selectedYear, setSelectedYear] = useState('');
   const [selectedPublisher, setSelectedPublisher] = useState('');
   const [minPages, setMinPages] = useState('');
   const [maxPages, setMaxPages] = useState('');
-  const [isFilterPopupOpen, setIsFilterPopupOpen] = useState(false); // This will be removed
+  const [currentView, setCurrentView] = useState('grid'); // Added state for view, default to grid
   const router = useRouter();
 
   // Memoized lists for dropdowns (moved from FilterPopup)
@@ -52,8 +54,8 @@ export default function BookListClient({ initialBooks }) {
     // setSortOrder('alphabetical'); // Optionally reset sort order
   };
 
-  // Memoized variable for filtered books based on the search term and sort order
-  const filteredBooks = useMemo(() => {
+  // Memoized variable for filtered and processed books
+  const processedBooks = useMemo(() => {
     if (!initialBooks || !initialBooks.data || !Array.isArray(initialBooks.data)) return [];
 
     const minPagesNumeric = minPages !== '' ? parseInt(minPages, 10) : null;
@@ -61,59 +63,42 @@ export default function BookListClient({ initialBooks }) {
     const yearNumeric = selectedYear !== '' ? parseInt(selectedYear, 10) : null;
 
     let booksArray = initialBooks.data.filter(book => {
-      // Search term filter (existing)
       const searchTermMatch = book.Title.toLowerCase().includes(searchTerm.toLowerCase());
       if (!searchTermMatch) return false;
-
-      // Year filter
-      if (yearNumeric !== null && book.Year !== yearNumeric) {
-        return false;
-      }
-
-      // Publisher filter
-      if (selectedPublisher && book.Publisher && book.Publisher.toLowerCase() !== selectedPublisher.toLowerCase()) {
-        return false;
-      }
-
-      // Min pages filter
-      if (minPagesNumeric !== null && (!book.Pages || book.Pages < minPagesNumeric)) {
-        return false;
-      }
-
-      // Max pages filter
-      if (maxPagesNumeric !== null && (!book.Pages || book.Pages > maxPagesNumeric)) {
-        return false;
-      }
-
+      if (yearNumeric !== null && book.Year !== yearNumeric) return false;
+      if (selectedPublisher && book.Publisher && book.Publisher.toLowerCase() !== selectedPublisher.toLowerCase()) return false;
+      if (minPagesNumeric !== null && (!book.Pages || book.Pages < minPagesNumeric)) return false;
+      if (maxPagesNumeric !== null && (!book.Pages || book.Pages > maxPagesNumeric)) return false;
       return true;
     });
 
-    // Apply sorting using sortConfig
     if (sortConfig.key) {
       booksArray.sort((a, b) => {
         let valA = a[sortConfig.key];
         let valB = b[sortConfig.key];
 
-        if (sortConfig.key === 'Year') { // Assuming 'Year' is the property for publication year
-          valA = parseInt(valA, 10) || 0; // Fallback to 0 if parsing fails
+        if (sortConfig.key === 'Year') {
+          valA = parseInt(valA, 10) || 0;
           valB = parseInt(valB, 10) || 0;
         } else if (typeof valA === 'string') {
           valA = valA.toLowerCase();
           valB = valB.toLowerCase();
         }
 
-        if (valA < valB) {
-          return sortConfig.direction === 'ascending' ? -1 : 1;
-        }
-        if (valA > valB) {
-          return sortConfig.direction === 'ascending' ? 1 : -1;
-        }
+        if (valA < valB) return sortConfig.direction === 'ascending' ? -1 : 1;
+        if (valA > valB) return sortConfig.direction === 'ascending' ? 1 : -1;
         return 0;
       });
     }
     
-
-    return booksArray;
+    // Transform data for ContentDisplay
+    return booksArray.map(book => ({
+      id: book.id,
+      title: book.Title,
+      imageUrl: book.coverImageUrl && book.coverImageUrl !== "NO_COVER_AVAILABLE" ? book.coverImageUrl : null,
+      description: `${book.authors ? book.authors.join(', ') : 'Unknown Author'} - ${book.Year || 'Unknown Year'}`,
+      linkUrl: `/pages/books/${book.id}`,
+    }));
   }, [initialBooks, searchTerm, sortConfig, selectedYear, selectedPublisher, minPages, maxPages]);
 
   const requestSort = (key) => {
@@ -134,11 +119,10 @@ export default function BookListClient({ initialBooks }) {
   }
 
   return (
-    <div className="py-12"> {/* Removed px-8 and transition classes */}
-      {/* Main layout: Flex container for sidebar and content */}
+    <div className="py-12">
       <div className="flex flex-col md:flex-row gap-6 md:justify-center">
         {/* Left Sidebar for Filters */}
-        <div className="hidden md:block md:w-1/8 p-4 bg-[var(--background-color)] rounded-lg shadow self-start"> {/* Added self-start for alignment */}
+        <div className="hidden md:block md:w-1/8 p-4 bg-[var(--background-color)] rounded-lg shadow self-start">
           <h2 className="text-xl font-semibold text-[var(--text-color)] mb-4">Filters</h2>
           {/* Year Filter */}
           <div className="mb-4">
@@ -199,7 +183,6 @@ export default function BookListClient({ initialBooks }) {
             </div>
           </div>
           
-          {/* Reset Filters Button */}
           <button
             onClick={handleResetFilters}
             className="w-full bg-[var(--accent-color)] hover:bg-[var(--hover-accent-color)] text-[var(--text-color)] font-bold py-2 px-4 rounded"
@@ -208,80 +191,43 @@ export default function BookListClient({ initialBooks }) {
           </button>
         </div>
 
-        {/* Main Content Area: Search, Sort, and Books List */}
+        {/* Main Content Area: Search, Sort, ViewSwitcher, and ContentDisplay */}
         <div className="w-full md:w-6/8 px-4 md:px-0">
-          {/* Use new SearchAndSortControls component */}
-          <SearchAndSortControls
-            searchTerm={searchTerm}
-            sortConfig={sortConfig}
-            onSearchChange={(e) => setSearchTerm(e.target.value)}
-            onRequestSort={requestSort}
-            sortOptions={[
-              { key: 'Title', label: 'Title', title: 'Title' }, // Use 'Title' to match book data property
-              { key: 'Year', label: 'Year', year: 'Year' }      // Use 'Year' to match book data property
-            ]}
-            searchPlaceholder="Search by book title..."
-          />
+          <div className="flex flex-col sm:flex-row justify-between items-center mb-4 gap-4">
+            <SearchAndSortControls
+              searchTerm={searchTerm}
+              sortConfig={sortConfig}
+              onSearchChange={(e) => setSearchTerm(e.target.value)}
+              onRequestSort={requestSort}
+              sortOptions={[
+                { key: 'Title', label: 'Title', title: 'Title' },
+                { key: 'Year', label: 'Year', year: 'Year' }
+              ]}
+              searchPlaceholder="Search by book title..."
+              className="flex-grow"
+            />
+            <ViewSwitcher currentView={currentView} onViewChange={setCurrentView} />
+          </div>
 
-          {/* Books List Display */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6"> {/* Responsive grid */}
-            {filteredBooks.map((book, index) => (
-              <Link key={book.id} href={`/pages/books/${book.id}`} className="group bg-[var(--background-color)] rounded-lg shadow border border-black hover:border-black transition-all duration-300 ease-in-out flex flex-col overflow-hidden h-full hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-black"> {/* Changed border to black and focus ring to black */}
-                {/* Entire card is a link, so no separate key needed on the inner div if we remove it or change its role */}
-                {/* Book Cover Image */}
-                <div className="relative w-full h-72 flex items-center justify-center bg-neutral-700 overflow-hidden rounded-t-lg">
-              {book.coverImageUrl && book.coverImageUrl !== "NO_COVER_AVAILABLE" ? (
-                    <Image
-                      src={book.coverImageUrl}
-                      alt={`Cover of ${book.Title}`}
-                      fill
-                      style={{ objectFit: "contain" }}
-                      className="transition-transform duration-300 group-hover:scale-105 rounded-t-lg"
-                      priority={index < 8} // Approximate priority with eager loading for first few images
-                    />
-                  ) : (
-                    <div
-                      className="w-full h-full flex items-center justify-center text-neutral-500 text-sm"
-                    >
-                      No Image
-                    </div>
-                  )}
-                </div>
-                {/* Book Details */}
-                <div className="p-4 flex flex-col flex-grow bg-gray-700 text-gray-200"> {/* Dark background and light text for contrast */}
-                     <h2 className="text-lg font-semibold text-red-500 mb-1 truncate" title={book.Title}> {/* Ensure title is visible and red */}
-                        {book.Title}
-                     </h2>
-                     {book.authors && Array.isArray(book.authors) && book.authors.length > 0 && (
-                        <p className="text-xs text-gray-300 mb-1 truncate" title={book.authors.join(', ')}> {/* Adjusted for dark bg */}
-                            By: {book.authors.join(', ')}
-                        </p>
-                     )}
-                     {/* Display publishedDate if available (from Google Books), otherwise fallback to Year */}
-                     {book.publishedDate && <p className="text-xs text-gray-300 mb-1">Published: {book.publishedDate}</p>}
-                     {!book.publishedDate && book.Year && <p className="text-xs text-gray-300 mb-1">Year: {book.Year}</p>}
+          <ContentDisplay items={processedBooks} view={currentView} />
 
-                     {/* "View Details" link removed as the whole card is a link */}
-                     {/* <div className="mt-auto pt-2">  */}
-                        {/* <span className="text-sm text-[var(--accent-color)] font-medium">View Details</span> */}
-                     {/* </div> */}
-                 </div>
-          </Link>
-         ))}
-     </div>
-     {/* Display a message if no books match the search term */}
-     {filteredBooks.length === 0 && searchTerm && (
-         <p className="text-center text-[var(--text-color)] mt-4">No books found matching your search.</p>
-     )}
-          {/* Display a message if no books match the filters (excluding search) */}
-          {filteredBooks.length === 0 && !searchTerm && (selectedYear || selectedPublisher || minPages || maxPages) && (
+          {processedBooks.length === 0 && searchTerm && (
+            <p className="text-center text-[var(--text-color)] mt-4">No books found matching your search.</p>
+          )}
+          {processedBooks.length === 0 && !searchTerm && (selectedYear || selectedPublisher || minPages || maxPages) && (
             <p className="text-center text-[var(--text-color)] mt-4">No books found matching your filter criteria.</p>
           )}
-        </div> {/* End of Main Content Area */}
+           {processedBooks.length === 0 && !searchTerm && !selectedYear && !selectedPublisher && !minPages && !maxPages && initialBooks?.data?.length > 0 && (
+            <p className="text-center text-[var(--text-color)] mt-4">No books to display with current filters. Try broadening your criteria.</p>
+          )}
+           {initialBooks?.data?.length === 0 && (
+             <p className="text-center text-[var(--text-color)] mt-4">There are no books to display at the moment.</p>
+           )}
+        </div>
 
         {/* Right Empty Sidebar for spacing */}
         <div className="hidden md:block md:w-1/8"></div>
-      </div> {/* End of Main Flex Container */}
+      </div>
       <div className="text-center mt-12"><Link href="/" className="home-link text-xl">Return to Home</Link></div>
     </div>
   );


### PR DESCRIPTION
Implemented reusable components for displaying content in either a list or grid view, controlled by a view switcher component.

New Components:
- `ListViewIcon` & `GridViewIcon`: SVG icons for the switcher.
- `ViewSwitcher`: Allows users to toggle between list and grid views.
- `ListItem`: Displays item details in a row format.
- `ImageItem`: Displays item image prominently in a card format.
- `ContentDisplay`: Dynamically renders items using `ListItem` or `ImageItem` based on the selected view.

Integration:
- Integrated these components into the `BookListClient` for the books page.
- Data transformation logic added to adapt book data for the new components.
- View switcher is placed alongside search/sort controls.

Styling:
- Components are styled with Tailwind CSS and support responsive layouts.
- Icons and components are designed to work with light/dark themes.