### PR TITLE
feat: Add clickable links to 'Based On' column for Adapted Works

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,20 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ['books.google.com', 'googleapis.com'], // Reverted to original domains
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'books.google.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'googleapis.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'upload.wikimedia.org',
+      },
+    ],
   },
 };
 

--- a/src/app/components/ContentDisplay.js
+++ b/src/app/components/ContentDisplay.js
@@ -1,0 +1,55 @@
+// src/app/components/ContentDisplay.js
+import ListItem from './ListItem';
+import ImageItem from './ImageItem';
+
+const ContentDisplay = ({ items, view = 'list', columns = [] }) => { // Added columns prop
+  if (!items || items.length === 0) {
+    return <p className="text-gray-500 dark:text-gray-400 text-center py-8">No items to display.</p>;
+  }
+
+  if (view === 'list') {
+    if (columns.length === 0) {
+      return <p className="text-red-500 text-center py-8">List view selected, but no column definitions provided.</p>;
+    }
+    return (
+      <div className="overflow-x-auto shadow-md sm:rounded-lg">
+        <table className="min-w-full w-full text-left text-sm text-gray-500 dark:text-gray-400">
+          <thead className="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-gray-700 border-b-2 border-red-500">
+            <tr>
+              {columns.map((col) => (
+                <th scope="col" key={col.key} className="px-6 py-3">
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+            {items.map((item, index) => (
+              <ListItem
+                key={item.id || item.title || index}
+                item={item}
+                columns={columns} // Pass columns to ListItem
+                rowIndex={index} // For zebra striping
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+
+  if (view === 'grid') {
+    // Grid view remains unchanged, does not use 'columns' prop in the same way
+    return (
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4 md:gap-6">
+        {items.map((item) => (
+          <ImageItem key={item.id || item.title} item={item} />
+        ))}
+      </div>
+    );
+  }
+
+  return <p className="text-red-500">Unknown view type selected.</p>;
+};
+
+export default ContentDisplay;

--- a/src/app/components/ImageItem.js
+++ b/src/app/components/ImageItem.js
@@ -1,0 +1,44 @@
+// src/app/components/ImageItem.js
+import Image from 'next/image'; // Using next/image for optimization
+
+const ImageItem = ({ item }) => {
+  const { title, imageUrl, linkUrl } = item;
+
+  const content = (
+    <div className="group relative aspect-[3/4] w-full bg-gray-100 dark:bg-gray-800 rounded-lg overflow-hidden shadow-md hover:shadow-xl transition-shadow duration-300">
+      {imageUrl ? (
+        <Image
+          src={imageUrl}
+          alt={title || 'Item image'}
+          layout="fill"
+          objectFit="cover"
+          className="bg-gray-200 dark:bg-gray-700 transition-transform duration-300 group-hover:scale-105"
+        />
+      ) : (
+        <div className="w-full h-full flex items-center justify-center bg-gray-200 dark:bg-gray-700">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-12 h-12 text-gray-400 dark:text-gray-500">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" /> {/* Simple X as placeholder */}
+          </svg>
+        </div>
+      )}
+      <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+      <div className="absolute bottom-0 left-0 right-0 p-4">
+        <h3 className="text-base font-semibold text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300 delay-100 transform translate-y-4 group-hover:translate-y-0">
+          {title || 'Untitled Item'}
+        </h3>
+      </div>
+    </div>
+  );
+
+  if (linkUrl) {
+    return (
+      <a href={linkUrl} target="_blank" rel="noopener noreferrer" className="block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 rounded-lg">
+        {content}
+      </a>
+    );
+  }
+
+  return content;
+};
+
+export default ImageItem;

--- a/src/app/components/ListItem.js
+++ b/src/app/components/ListItem.js
@@ -1,0 +1,43 @@
+// src/app/components/ListItem.js
+import Link from 'next/link';
+
+const ListItem = ({ item, columns, rowIndex }) => {
+  if (!columns || columns.length === 0) {
+    return (
+      <tr className="border-b dark:border-gray-700"> {/* Fallback border if not in a proper table */}
+        <td colSpan={100} className="px-6 py-4 text-red-500 text-center">Column definitions missing for ListItem.</td>
+      </tr>
+    );
+  }
+
+  const isEvenRow = rowIndex % 2 === 0;
+  // Zebra striping for content rows.
+  // Light theme: even rows white, odd rows gray-50.
+  // Dark theme: even rows gray-800, odd rows gray-900.
+  // Hover states are slightly darker than the non-hover state of the OTHER stripe color for better contrast.
+  const rowClasses = `
+    ${isEvenRow ? 'bg-white dark:bg-gray-800' : 'bg-gray-50 dark:bg-gray-900'}
+    hover:bg-gray-200 dark:hover:bg-gray-700
+    transition-colors duration-150
+  `;
+
+  return (
+    <tr className={rowClasses.trim()}>
+      {columns.map((col) => (
+        <td key={col.key} className="px-6 py-4 text-gray-700 dark:text-gray-300 whitespace-normal align-top"> {/* Added align-top for consistency if cell content varies in height */}
+          {typeof col.render === 'function' ? (
+            col.render(item) // Use custom render function
+          ) : col.isLink && item.linkUrl ? ( // Fallback to default link rendering for the designated 'isLink' column
+            <Link href={item.linkUrl} className="hover:underline text-indigo-600 dark:text-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-300 rounded">
+              {String(item[col.key] ?? '-')}
+            </Link>
+          ) : ( // Fallback to default text rendering
+            String(item[col.key] ?? '-')
+          )}
+        </td>
+      ))}
+    </tr>
+  );
+};
+
+export default ListItem;

--- a/src/app/components/ViewSwitcher.js
+++ b/src/app/components/ViewSwitcher.js
@@ -1,0 +1,33 @@
+// src/app/components/ViewSwitcher.js
+import ListViewIcon from './icons/ListViewIcon';
+import GridViewIcon from './icons/GridViewIcon';
+
+const ViewSwitcher = ({ currentView, onViewChange }) => {
+  const commonButtonClasses = "p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500";
+  const activeButtonClasses = "bg-indigo-100 text-indigo-700 dark:bg-indigo-700 dark:text-indigo-100";
+  const inactiveButtonClasses = "text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200";
+  const iconClasses = "w-6 h-6";
+
+  return (
+    <div className="flex space-x-2">
+      <button
+        onClick={() => onViewChange('list')}
+        aria-label="Switch to list view"
+        title="List View"
+        className={`${commonButtonClasses} ${currentView === 'list' ? activeButtonClasses : inactiveButtonClasses}`}
+      >
+        <ListViewIcon className={iconClasses} />
+      </button>
+      <button
+        onClick={() => onViewChange('grid')}
+        aria-label="Switch to grid view"
+        title="Grid View"
+        className={`${commonButtonClasses} ${currentView === 'grid' ? activeButtonClasses : inactiveButtonClasses}`}
+      >
+        <GridViewIcon className={iconClasses} />
+      </button>
+    </div>
+  );
+};
+
+export default ViewSwitcher;

--- a/src/app/components/icons/GridViewIcon.js
+++ b/src/app/components/icons/GridViewIcon.js
@@ -1,0 +1,20 @@
+// src/app/components/icons/GridViewIcon.js
+const GridViewIcon = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    aria-hidden="true"
+    {...props} // Pass through any other props like className, width, height
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25A2.25 2.25 0 0 1 13.5 18v-2.25Z"
+    />
+  </svg>
+);
+
+export default GridViewIcon;

--- a/src/app/components/icons/ListViewIcon.js
+++ b/src/app/components/icons/ListViewIcon.js
@@ -1,0 +1,20 @@
+// src/app/components/icons/ListViewIcon.js
+const ListViewIcon = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    aria-hidden="true"
+    {...props} // Pass through any other props like className, width, height
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M8.25 6.75h12M8.25 12h12m-12 5.25h12M3.75 6.75h.007v.008H3.75V6.75Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0ZM3.75 12h.007v.008H3.75V12Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm-.375 5.25h.007v.008H3.75v-.008Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z"
+    />
+  </svg>
+);
+
+export default ListViewIcon;

--- a/src/app/pages/adapted-works/AdaptedWorksListClient.js
+++ b/src/app/pages/adapted-works/AdaptedWorksListClient.js
@@ -1,48 +1,102 @@
 "use client";
 
 import React, { useState, useMemo } from 'react';
-import Link from 'next/link';
-import SearchAndSortControls from '@/app/components/SearchAndSortControls'; // Import the new component
+import Link from 'next/link'; // Added for the custom render function
+import SearchAndSortControls from '@/app/components/SearchAndSortControls';
+import ViewSwitcher from '@/app/components/ViewSwitcher';
+import ContentDisplay from '@/app/components/ContentDisplay';
 
 export default function AdaptedWorksListClient({ adaptations: initialAdaptations }) {
   const [searchTerm, setSearchTerm] = useState('');
-  const [sortConfig, setSortConfig] = useState({ key: 'adaptationTitle', direction: 'ascending' });
+  const [sortConfig, setSortConfig] = useState({ key: 'title', direction: 'ascending' });
+  const [currentView, setCurrentView] = useState('grid');
 
-  const filteredAndSortedAdaptations = useMemo(() => {
-    let adaptableAdaptations = [...initialAdaptations];
+  const adaptedWorksColumns = [
+    { key: 'title', label: 'Title', isLink: true }, // This will use item.linkUrl for the main adaptation link
+    { key: 'yearDisplay', label: 'Year' },
+    { key: 'typeDisplay', label: 'Type' },
+    {
+      key: 'originalWorkInfo', // A key that represents the data unit for the column
+      label: 'Based On',
+      render: (item) => {
+        if (!item.originalWorkTitle) {
+          return <span className="text-gray-500 dark:text-gray-400">-</span>;
+        }
+        if (item.originalWorkLink) {
+          const commonLinkClasses = "hover:underline text-sky-600 dark:text-sky-400";
+          if (item.originalWorkLink.startsWith('/')) {
+            return (
+              <Link href={item.originalWorkLink} className={commonLinkClasses}>
+                {item.originalWorkTitle}
+              </Link>
+            );
+          } else if (item.originalWorkLink.startsWith('http')) {
+            return (
+              <a
+                href={item.originalWorkLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={commonLinkClasses}
+              >
+                {item.originalWorkTitle}
+              </a>
+            );
+          }
+        }
+        return item.originalWorkTitle; // Just text if no valid link
+      }
+    }
+  ];
 
-    // Filter logic
+  const processedAdaptations = useMemo(() => {
+    let items = [...initialAdaptations];
+
     if (searchTerm) {
-      adaptableAdaptations = adaptableAdaptations.filter(adaptation =>
-        adaptation.adaptationTitle.toLowerCase().includes(searchTerm.toLowerCase())
+      items = items.filter(adaptation =>
+        adaptation.adaptationTitle?.toLowerCase().includes(searchTerm.toLowerCase())
       );
     }
 
-    // Sorting logic
+    let transformedItems = items.map((adaptation, index) => ({
+      id: `${adaptation.adaptationTitle}-${adaptation.year}-${index}`,
+      title: adaptation.adaptationTitle || 'N/A',
+      yearDisplay: String(adaptation.year) || 'N/A',
+      typeDisplay: adaptation.type || 'N/A',
+      linkUrl: adaptation.adaptationLink,
+      imageUrl: adaptation.posterUrl || null,
+      originalYear: adaptation.year,
+      originalWorkTitle: adaptation.originalWorkTitle,
+      originalWorkLink: adaptation.originalWorkLink
+    }));
+
     if (sortConfig.key) {
-      adaptableAdaptations.sort((a, b) => {
-        let valA = a[sortConfig.key];
-        let valB = b[sortConfig.key];
-
-        // Handle numeric sorting for year
+      transformedItems.sort((a, b) => {
+        let valA, valB;
         if (sortConfig.key === 'year') {
-          valA = parseInt(valA, 10);
-          valB = parseInt(valB, 10);
-        } else if (typeof valA === 'string') { // Handle string sorting for title
-          valA = valA.toLowerCase();
-          valB = valB.toLowerCase();
+          valA = a.originalYear;
+          valB = b.originalYear;
+        } else {
+          valA = a[sortConfig.key];
+          valB = b[sortConfig.key];
         }
 
-        if (valA < valB) {
-          return sortConfig.direction === 'ascending' ? -1 : 1;
+        if (typeof valA === 'string') valA = valA.toLowerCase();
+        if (typeof valB === 'string') valB = valB.toLowerCase();
+
+        if (sortConfig.key === 'year') {
+            valA = Number(valA);
+            valB = Number(valB);
+        } else if (typeof valA !== 'number' && typeof valB !== 'number') {
+            valA = String(valA).toLowerCase();
+            valB = String(valB).toLowerCase();
         }
-        if (valA > valB) {
-          return sortConfig.direction === 'ascending' ? 1 : -1;
-        }
+
+        if (valA < valB) return sortConfig.direction === 'ascending' ? -1 : 1;
+        if (valA > valB) return sortConfig.direction === 'ascending' ? 1 : -1;
         return 0;
       });
     }
-    return adaptableAdaptations;
+    return transformedItems;
   }, [initialAdaptations, searchTerm, sortConfig]);
 
   const requestSort = (key) => {
@@ -54,90 +108,43 @@ export default function AdaptedWorksListClient({ adaptations: initialAdaptations
   };
 
   if (!initialAdaptations || initialAdaptations.length === 0) {
-    return (
-      <div className="px-8 py-12">
-        <p className="text-[var(--text-color)]">No adaptations information available.</p>
-      </div>
-    );
+    return <div className="px-8 py-12"><p className="text-[var(--text-color)]">No adaptations information available.</p></div>;
   }
 
   const sortOptions = [
-    { key: 'adaptationTitle', label: 'Title', title: 'Title' },
-    { key: 'year', label: 'Year', year: 'Year' }
+    { key: 'title', label: 'Title' },
+    { key: 'year', label: 'Year' }
   ];
 
   return (
-    <div className="container mx-auto px-4 py-8 text-[var(--text-color)] max-w-5xl">
-      <SearchAndSortControls
-        searchTerm={searchTerm}
-        sortConfig={sortConfig}
-        onSearchChange={(e) => setSearchTerm(e.target.value)}
-        onRequestSort={requestSort}
-        sortOptions={sortOptions}
-        searchPlaceholder="Search by adaptation title..."
+    <div className="container mx-auto px-4 py-8 text-[var(--text-color)]">
+      <div className="flex flex-col sm:flex-row items-center mb-4 sm:space-x-2">
+        <div className="flex-grow w-full sm:w-auto">
+          <SearchAndSortControls
+            searchTerm={searchTerm}
+            sortConfig={sortConfig}
+            onSearchChange={(e) => setSearchTerm(e.target.value)}
+            onRequestSort={requestSort}
+            sortOptions={sortOptions}
+            searchPlaceholder="Search by adaptation title..."
+          />
+        </div>
+        <div className="mt-2 sm:mt-0">
+          <ViewSwitcher currentView={currentView} onViewChange={setCurrentView} />
+        </div>
+      </div>
+
+      <ContentDisplay
+        items={processedAdaptations}
+        view={currentView}
+        columns={adaptedWorksColumns}
       />
 
-      {filteredAndSortedAdaptations.length > 0 ? (
-        <ul className="space-y-6">
-          {filteredAndSortedAdaptations.map((adaptation, index) => (
-            <li
-              key={`${adaptation.adaptationLink}-${index}-${adaptation.adaptationTitle}`} // Added title to key for better uniqueness
-              className="p-6 border border-[var(--border-color)] rounded-lg shadow-lg bg-[var(--background-start-rgb)] bg-opacity-50 backdrop-blur-md"
-            >
-              <h2 className="text-2xl font-semibold text-[var(--accent-color)] mb-2">
-                <a
-                  href={adaptation.adaptationLink}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="hover:underline"
-                >
-                  {adaptation.adaptationTitle}
-                </a>
-              </h2>
-            <div className="text-sm mt-1">
-              <div><strong className="font-medium">Year:</strong> {adaptation.year}</div>
-              <div><strong className="font-medium">Type:</strong> {adaptation.type}</div>
-              </div>
-              {adaptation.originalWorkTitle && (
-                <div className="mt-2 text-sm">
-                  <strong className="font-medium">Based on: </strong>
-                  {adaptation.originalWorkLink && adaptation.originalWorkLink.startsWith('http') ? (
-                    <a
-                      href={adaptation.originalWorkLink}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="italic text-[var(--link-color)] hover:underline"
-                    >
-                      {adaptation.originalWorkTitle}
-                    </a>
-                  ) : adaptation.originalWorkLink ? (
-                  <Link href={adaptation.originalWorkLink} legacyBehavior>
-                      <a className="italic text-[var(--link-color)] hover:underline">
-                        {adaptation.originalWorkTitle}
-                      </a>
-                    </Link>
-                  ) : (
-                    <span className="italic">{adaptation.originalWorkTitle}</span>
-                  )}
-                  {adaptation.originalWorkType && (
-                    <span className="text-gray-600 dark:text-gray-400"> ({adaptation.originalWorkType})</span>
-                  )}
-                </div>
-              )}
-              {adaptation.posterUrl && (
-                <div className="mt-4 max-w-xs mx-auto md:mx-0">
-                  <img
-                    src={adaptation.posterUrl}
-                    alt={`Poster for ${adaptation.adaptationTitle}`}
-                    className="rounded-lg shadow-lg object-contain w-full h-auto"
-                  />
-                </div>
-              )}
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <p className="text-center text-[var(--text-color)] py-10">No adaptations found matching your criteria.</p>
+      {processedAdaptations.length === 0 && searchTerm && (
+        <p className="text-center text-[var(--text-color)] py-10">No adaptations found matching your search.</p>
+      )}
+       {processedAdaptations.length === 0 && !searchTerm && initialAdaptations.length > 0 && (
+        <p className="text-center text-[var(--text-color)] py-10">All adaptations have been filtered out.</p>
       )}
     </div>
   );

--- a/src/app/pages/shorts/ShortListClient.js
+++ b/src/app/pages/shorts/ShortListClient.js
@@ -2,71 +2,75 @@
 
 import React, { useState, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
-import Link from 'next/link';
-import Image from 'next/image'; // Import Next.js Image component
-import TypeFilterMenu from '@/app/components/TypeFilterMenu'; // Import the new component
-import SearchAndSortControls from '@/app/components/SearchAndSortControls'; // Import the new component
+import Link from 'next/link'; // Keep for the "Return to Home" link
+import TypeFilterMenu from '@/app/components/TypeFilterMenu';
+import SearchAndSortControls from '@/app/components/SearchAndSortControls';
+import ContentDisplay from '@/app/components/ContentDisplay'; // Added
 
-/**
- * ShortListClient component for displaying and filtering a list of short stories.
- * @param {object} props - Component props.
- * @param {object} props.initialShorts - Initial list of short stories to display.
- * @returns {JSX.Element} The ShortListClient component.
- */
 export default function ShortListClient({ initialShorts }) {
-  // State variable for the search term
   const [searchTerm, setSearchTerm] = useState('');
-  // New sortConfig state
   const [sortConfig, setSortConfig] = useState({ key: 'title', direction: 'ascending' });
-  // State variable for search bar visibility - will be removed as SearchAndSortControls handles it
-  // const [isSearchBarVisible, setIsSearchBarVisible] = useState(false);
-  // State variable for the selected type
   const [selectedType, setSelectedType] = useState('');
   const router = useRouter();
 
-  // Memoized variable for unique types
+  const shortsColumns = [
+    { key: 'title', label: 'Title', isLink: true },
+    { key: 'typeDisplay', label: 'Type' },
+    { key: 'yearDisplay', label: 'Year' }
+  ];
+
   const uniqueTypes = useMemo(() => {
     if (!initialShorts || !initialShorts.data) return [];
     const types = new Set(initialShorts.data.map(short => short.type).filter(Boolean));
     return ['All', ...Array.from(types)];
   }, [initialShorts]);
 
-  // Memoized variable for filtered short stories based on the search term and sort order
-  const filteredShorts = useMemo(() => {
+  const processedShorts = useMemo(() => {
       if (!initialShorts || !initialShorts.data) return [];
-      let shortsArray = initialShorts.data.filter(short =>
-        short.title.toLowerCase().includes(searchTerm.toLowerCase())
+      let items = initialShorts.data.filter(short =>
+        short.title?.toLowerCase().includes(searchTerm.toLowerCase())
       );
 
       if (selectedType && selectedType !== 'All') {
-        shortsArray = shortsArray.filter(short => short.type === selectedType);
+        items = items.filter(short => short.type === selectedType);
       }
 
-      // Apply sorting using sortConfig
+      let transformedItems = items.map(short => ({
+          id: short.id,
+          title: short.title || "Untitled Short",
+          typeDisplay: short.type || 'N/A',
+          yearDisplay: short.year ? String(short.year) : 'N/A',
+          linkUrl: `/pages/shorts/${short.id}`,
+          originalYear: short.year
+      }));
+
       if (sortConfig.key) {
-        shortsArray.sort((a, b) => {
-          let valA = a[sortConfig.key];
-          let valB = b[sortConfig.key];
-
+        transformedItems.sort((a, b) => {
+          let valA, valB;
           if (sortConfig.key === 'year') {
-            valA = parseInt(valA, 10) || 0;
-            valB = parseInt(valB, 10) || 0;
-          } else if (typeof valA === 'string') { // For title
-            valA = valA.toLowerCase();
-            valB = valB.toLowerCase();
+            valA = a.originalYear;
+            valB = b.originalYear;
+          } else {
+            valA = a[sortConfig.key];
+            valB = b[sortConfig.key];
           }
 
-          if (valA < valB) {
-            return sortConfig.direction === 'ascending' ? -1 : 1;
+          if (typeof valA === 'string') valA = valA.toLowerCase();
+          if (typeof valB === 'string') valB = valB.toLowerCase();
+          if (sortConfig.key === 'year') {
+              valA = Number(valA);
+              valB = Number(valB);
+          } else if (typeof valA !== 'number' && typeof valB !== 'number') {
+             valA = String(valA).toLowerCase();
+             valB = String(valB).toLowerCase();
           }
-          if (valA > valB) {
-            return sortConfig.direction === 'ascending' ? 1 : -1;
-          }
+
+          if (valA < valB) return sortConfig.direction === 'ascending' ? -1 : 1;
+          if (valA > valB) return sortConfig.direction === 'ascending' ? 1 : -1;
           return 0;
         });
       }
-
-      return shortsArray;
+      return transformedItems;
     }, [initialShorts, searchTerm, sortConfig, selectedType]);
 
   const requestSort = (key) => {
@@ -77,17 +81,11 @@ export default function ShortListClient({ initialShorts }) {
     setSortConfig({ key, direction });
   };
 
-  // Function to handle selecting and navigating to a random short story
   const handleRandomShort = () => {
-    // Check if there are short stories available
     if (initialShorts && initialShorts.data && initialShorts.data.length > 0) {
-      // Generate a random index
       const randomIndex = Math.floor(Math.random() * initialShorts.data.length);
-      // Get the random short story
       const randomShort = initialShorts.data[randomIndex];
-      // Check if the short story and its ID are valid
       if (randomShort && randomShort.id) {
-        // Navigate to the short story's page
         router.push(`/pages/shorts/${randomShort.id}`);
       } else {
         console.error("Failed to get random short story or ID is missing", randomShort);
@@ -97,76 +95,61 @@ export default function ShortListClient({ initialShorts }) {
     }
   };
 
-  return (
-    <div className="py-12"> {/* Removed pr-8 to allow full width for centering */}
+  const sortOptions = [
+    { key: 'title', label: 'Title' },
+    { key: 'year', label: 'Year' }
+  ];
 
-      {/* Main layout: Flex container for sidebar and content */}
-      {/* Added md:justify-center to center the content block on medium screens and up */}
-      <div className="flex flex-col md:flex-row gap-6 md:justify-center"> {/* Adjusted flex direction for mobile and gap */}
-        {/* Left Sidebar for Type Filters ONLY - Hidden on mobile, shown on md and up */}
-        {/* Reduced width from md:w-1/4 to md:w-1/8 */}
-        <div className="hidden md:block md:w-1/8">
+  return (
+    <div className="py-12">
+      <div className="flex flex-col md:flex-row gap-6 md:justify-center">
+        <div className="hidden md:block md:w-1/8 p-4 bg-[var(--background-color)] rounded-lg shadow self-start">
           <TypeFilterMenu
             uniqueTypes={uniqueTypes}
             selectedType={selectedType}
             onSelectType={setSelectedType}
           />
+           <button
+            onClick={handleRandomShort}
+            className="mt-4 w-full bg-orange-500 hover:bg-orange-600 text-white font-bold py-2 px-4 rounded transition-colors"
+            title="Go to a random short story"
+            aria-label="Go to a random short story"
+          >
+            Random Short
+          </button>
         </div>
 
-        {/* Right Content Area for Search, Sort, and Shorts List - Takes full width on mobile, 6/8 (3/4) on medium+ */}
-        {/* Adjusted width to md:w-6/8 */}
-        <div className="w-full md:w-6/8 px-4 md:px-0"> {/* Added horizontal padding for mobile, removed for md+ to rely on parent centering */}
-          {/* Use new SearchAndSortControls component */}
-          <SearchAndSortControls
-            searchTerm={searchTerm}
-            sortConfig={sortConfig}
-            onSearchChange={(e) => setSearchTerm(e.target.value)}
-            onRequestSort={requestSort}
-            sortOptions={[
-              { key: 'title', label: 'Title', title: 'Title' }, // Property name is 'title'
-              { key: 'year', label: 'Year', year: 'Year' }        // Property name is 'year'
-            ]}
-            searchPlaceholder="Search by short story title..."
+        <div className="w-full md:w-6/8 px-4 md:px-0">
+          <div className="mb-4">
+            <SearchAndSortControls
+              searchTerm={searchTerm}
+              sortConfig={sortConfig}
+              onSearchChange={(e) => setSearchTerm(e.target.value)}
+              onRequestSort={requestSort}
+              sortOptions={sortOptions}
+              searchPlaceholder="Search by short story title..."
+            />
+          </div>
+
+          <ContentDisplay
+            items={processedShorts}
+            view={'list'}
+            columns={shortsColumns}
           />
 
-          {/* Header Row for List */}
-          <div className="flex justify-between items-center p-4 text-[var(--accent-color)] text-lg font-bold">
-            <div className="flex-1 text-left">Title</div>
-            <div className="flex-1 text-center">Type</div>
-            <div className="flex-1 text-right">Year</div>
-          </div>
-          {/* Separator Line */}
-          <hr className="mb-2 border-[var(--accent-color)] border-t-2" />
-
-          {/* Shorts List Display */}
-          {/* Renders the list of filtered short stories */}
-          <div className="shorts-list-container flex flex-col gap-2">
-            {filteredShorts.map(short => (
-                <div key={short.id} className="short-item p-4 rounded-lg shadow transition-colors"> {/* Removed border classes */}
-                  <Link href={`/pages/shorts/${short.id}`} className="flex justify-between items-center w-full">
-                      <div className="flex-1 text-left text-base text-[var(--text-color)] truncate pr-2">
-                          {short.title}
-                      </div>
-                      <div className="flex-1 text-center text-base text-[var(--text-color)] px-2 capitalize">
-                          {short.type || 'N/A'} {/* Display type or N/A if not available */}
-                      </div>
-                      <div className="flex-1 text-right text-base text-[var(--text-color)] pl-2">
-                          {short.year || 'N/A'} {/* Display year or N/A if not available */}
-                      </div>
-                  </Link>
-                </div>
-            ))}
-          </div>
-          {/* Display a message if no short stories match the search term */}
-          {filteredShorts.length === 0 && searchTerm && (
+          {processedShorts.length === 0 && searchTerm && (
               <p className="text-center text-[var(--text-color)] mt-4">No shorts found matching your search.</p>
           )}
-          {/* Display a message if no short stories match the type filter */}
-          {filteredShorts.length === 0 && selectedType && selectedType !== 'All' && (
+          {processedShorts.length === 0 && selectedType && selectedType !== 'All' && !searchTerm && (
             <p className="text-center text-[var(--text-color)] mt-4">No shorts found for the type &apos;{selectedType}&apos;.</p>
           )}
+           {processedShorts.length === 0 && !searchTerm && (!selectedType || selectedType === 'All') && initialShorts?.data?.length > 0 && (
+             <p className="text-center text-[var(--text-color)] mt-4">All shorts have been filtered out.</p> // Changed message slightly
+           )}
+            {initialShorts?.data?.length === 0 && (
+             <p className="text-center text-[var(--text-color)] mt-4">No shorts available at the moment.</p>
+           )}
         </div>
-        {/* Empty div for right-side spacing on medium screens and up, matches sidebar width */}
         <div className="hidden md:block md:w-1/8"></div>
       </div>
       <div className="text-center mt-12"><Link href="/" className="home-link text-xl">Return to Home</Link></div>

--- a/src/app/pages/villains/VillainListClient.js
+++ b/src/app/pages/villains/VillainListClient.js
@@ -1,70 +1,66 @@
 "use client";
 
 import React, { useState, useMemo } from 'react';
-import { useRouter } from 'next/navigation';
-import Link from 'next/link';
-import Image from 'next/image'; // Import Next.js Image component
-import StatusFilterMenu from '@/app/components/StatusFilterMenu'; // Import the new component
-import SearchAndSortControls from '@/app/components/SearchAndSortControls'; // Import the new component
+// useRouter can be removed if not used directly
+// import { useRouter } from 'next/navigation';
+import Link from 'next/link'; // Keep for "Return to Home" link
+// Image component is not needed for this client
+// import Image from 'next/image';
+import StatusFilterMenu from '@/app/components/StatusFilterMenu';
+import SearchAndSortControls from '@/app/components/SearchAndSortControls';
+import ContentDisplay from '@/app/components/ContentDisplay'; // Added
 
-/**
- * VillainListClient component for displaying and filtering a list of villains.
- * @param {object} props - Component props.
- * @param {object} props.initialVillains - Initial list of villains to display.
- * @returns {JSX.Element} The VillainListClient component.
- */
 export default function VillainListClient({ initialVillains }) {
-  // State variable for the search term
   const [searchTerm, setSearchTerm] = useState('');
-  // New sortConfig state
   const [sortConfig, setSortConfig] = useState({ key: 'name', direction: 'ascending' });
-  // State variable for search bar visibility - will be removed
-  // const [isSearchBarVisible, setIsSearchBarVisible] = useState(false);
-  // State variable for the selected status
   const [selectedStatus, setSelectedStatus] = useState('');
-  const router = useRouter();
+  // const router = useRouter(); // Not directly used in this simplified version
 
-  // Memoized variable for unique statuses
+  const villainColumns = [
+    { key: 'name', label: 'Name', isLink: true },
+    { key: 'statusDisplay', label: 'Status' }
+  ];
+
   const uniqueStatuses = useMemo(() => {
     if (!initialVillains || !initialVillains.data) return [];
     const statuses = new Set(initialVillains.data.map(villain => villain.status).filter(Boolean));
     return ['All', ...Array.from(statuses)];
   }, [initialVillains]);
 
-  // Memoized variable for filtered villains based on the search term, sort order, and selected status
-  const filteredVillains = useMemo(() => {
+  const processedVillains = useMemo(() => {
     if (!initialVillains || !initialVillains.data) return [];
-    let processableVillains = [...initialVillains.data];
+    let items = [...initialVillains.data];
 
-    // Filter by search term first
     if (searchTerm) {
-      processableVillains = processableVillains.filter(villain =>
-        villain.name.toLowerCase().includes(searchTerm.toLowerCase())
+      items = items.filter(villain =>
+        villain.name?.toLowerCase().includes(searchTerm.toLowerCase())
       );
     }
 
-    // Filter by status
     if (selectedStatus && selectedStatus !== 'All') {
-      processableVillains = processableVillains.filter(villain => villain.status === selectedStatus);
+      items = items.filter(villain => villain.status === selectedStatus);
     }
 
-    // Sort villains using sortConfig
-    if (sortConfig.key) { // key will be 'name'
-      processableVillains.sort((a, b) => {
-        const valA = a[sortConfig.key].toLowerCase();
-        const valB = b[sortConfig.key].toLowerCase();
+    let transformedItems = items.map(villain => ({
+        id: villain.id,
+        // Use 'name' for the 'name' column key, and ensure it's what `isLink` uses
+        name: villain.name || "Unnamed Villain",
+        statusDisplay: villain.status || 'N/A',
+        linkUrl: `/pages/villains/${villain.id}`,
+    }));
 
-        if (valA < valB) {
-          return sortConfig.direction === 'ascending' ? -1 : 1;
-        }
-        if (valA > valB) {
-          return sortConfig.direction === 'ascending' ? 1 : -1;
-        }
+    if (sortConfig.key) {
+      transformedItems.sort((a, b) => {
+        // Assuming sortConfig.key will always be 'name' for villains as per sortOptions
+        const valA = a[sortConfig.key]?.toLowerCase() || '';
+        const valB = b[sortConfig.key]?.toLowerCase() || '';
+
+        if (valA < valB) return sortConfig.direction === 'ascending' ? -1 : 1;
+        if (valA > valB) return sortConfig.direction === 'ascending' ? 1 : -1;
         return 0;
       });
     }
-
-    return processableVillains;
+    return transformedItems;
   }, [initialVillains, searchTerm, sortConfig, selectedStatus]);
 
   const requestSort = (key) => {
@@ -75,15 +71,12 @@ export default function VillainListClient({ initialVillains }) {
     setSortConfig({ key, direction });
   };
 
-  return (
-    <div className="py-12"> {/* Removed pr-8 to allow full width for centering */}
+  const sortOptions = [{ key: 'name', label: 'Name' }]; // Only sorting by name
 
-      {/* Main layout: Flex container for sidebar and content */}
-      {/* Added md:justify-center to center the content block on medium screens and up */}
-      <div className="flex flex-col md:flex-row gap-6 md:justify-center"> {/* Adjusted flex direction for mobile and gap */}
-        {/* Left Sidebar for Status Filters ONLY - Hidden on mobile, shown on md and up */}
-        {/* Reduced width from md:w-1/4 to md:w-1/8 */}
-        <div className="hidden md:block md:w-1/8">
+  return (
+    <div className="py-12">
+      <div className="flex flex-col md:flex-row gap-6 md:justify-center">
+        <div className="hidden md:block md:w-1/8 p-4 bg-[var(--background-color)] rounded-lg shadow self-start">
           <StatusFilterMenu
             uniqueStatuses={uniqueStatuses}
             selectedStatus={selectedStatus}
@@ -91,57 +84,37 @@ export default function VillainListClient({ initialVillains }) {
           />
         </div>
 
-        {/* Right Content Area for Search, Sort, and Villains List - Takes full width on mobile, 6/8 (3/4) on medium+ */}
-        {/* Adjusted width to md:w-6/8 */}
-        <div className="w-full md:w-6/8 px-4 md:px-0"> {/* Added horizontal padding for mobile, removed for md+ to rely on parent centering */}
-          {/* Use new SearchAndSortControls component */}
-          <SearchAndSortControls
-            searchTerm={searchTerm}
-            sortConfig={sortConfig}
-            onSearchChange={(e) => setSearchTerm(e.target.value)}
-            onRequestSort={requestSort}
-            sortOptions={[{ key: 'name', label: 'Name', title: 'Name' }]} // Property is 'name'
-            searchPlaceholder="Search by villain name..."
-          />
-      {/* Header Row for List */}
-      <div className="flex justify-between items-center p-4 text-[var(--accent-color)] text-lg font-bold">
-        <div className="flex-1 text-left">Name</div>
-        <div className="flex-1 text-right">Status</div>
-      </div>
-      {/* Separator Line */}
-      <hr className="mb-2 border-[var(--accent-color)] border-t-2" />
-
-      {/* Villains List Display */}
-      {/* Renders the list of filtered villains */}
-      <div className="villains-list-container flex flex-col gap-2">
-        {filteredVillains.map((villain, index) => (
-          <div
-            key={villain.id}
-            className={`villain-item p-4 rounded-lg shadow transition-colors ${
-              index % 2 === 0 ? 'bg-[var(--row-bg-even)]' : 'bg-[var(--row-bg-odd)]'
-            }`}
-          >
-            <Link href={`/pages/villains/${villain.id}`} className="flex justify-between items-center w-full">
-              <div className="flex-1 text-left text-base text-[var(--text-color)] truncate pr-2">
-                {villain.name}
-              </div>
-              <div className="flex-1 text-right text-base text-[var(--text-color)] pl-2 capitalize">
-                {villain.status || 'N/A'} {/* Display status or N/A if not available */}
-              </div>
-            </Link>
+        <div className="w-full md:w-6/8 px-4 md:px-0">
+          <div className="mb-4">
+            <SearchAndSortControls
+              searchTerm={searchTerm}
+              sortConfig={sortConfig}
+              onSearchChange={(e) => setSearchTerm(e.target.value)}
+              onRequestSort={requestSort}
+              sortOptions={sortOptions}
+              searchPlaceholder="Search by villain name..."
+            />
           </div>
-        ))}
-      </div>
-      {/* Display a message if no villains match the search term */}
-     {filteredVillains.length === 0 && searchTerm && (
-         <p className="text-center text-[var(--text-color)] mt-4">No villains found matching your search.</p>
-     )}
-      {/* Display a message if no villains match the status filter */}
-      {filteredVillains.length === 0 && selectedStatus && selectedStatus !== 'All' && (
-        <p className="text-center text-[var(--text-color)] mt-4">No villains found for the status &apos;{selectedStatus}&apos;.</p>
-      )}
+
+          <ContentDisplay
+            items={processedVillains}
+            view={'list'} // Hardcoded to list view
+            columns={villainColumns}
+          />
+
+          {processedVillains.length === 0 && searchTerm && (
+              <p className="text-center text-[var(--text-color)] mt-4">No villains found matching your search.</p>
+          )}
+          {processedVillains.length === 0 && selectedStatus && selectedStatus !== 'All' && !searchTerm &&(
+            <p className="text-center text-[var(--text-color)] mt-4">No villains found for the status &apos;{selectedStatus}&apos;.</p>
+          )}
+          {processedVillains.length === 0 && !searchTerm && (!selectedStatus || selectedStatus === 'All') && initialVillains?.data?.length > 0 && (
+             <p className="text-center text-[var(--text-color)] mt-4">All villains have been filtered out.</p>
+           )}
+           {initialVillains?.data?.length === 0 && (
+             <p className="text-center text-[var(--text-color)] mt-4">No villains available at the moment.</p>
+           )}
         </div>
-        {/* Empty div for right-side spacing on medium screens and up, matches sidebar width */}
         <div className="hidden md:block md:w-1/8"></div>
       </div>
       <div className="text-center mt-12"><Link href="/" className="home-link text-xl">Return to Home</Link></div>


### PR DESCRIPTION
Enhanced the list view for the 'Adapted Works' page:
- The 'Based On' column now displays clickable links to the original work.
- Internal links (e.g., to book/short story pages within the site) use Next.js <Link>.
- External links (e.g., to Wikipedia) use standard <a> tags opening in a new tab.
- Plain text is shown if a link is not available but a title is.

Implementation Details:
- Modified `ListItem.js` to support a custom `render` function for table cells, allowing for more complex cell content.
- Updated `AdaptedWorksListClient.js` to:
    - Provide `originalWorkTitle` and `originalWorkLink` in the processed data.
    - Use the new `render` capability in its `columns` definition for the 'Based On' column to generate the appropriate links.