### PR TITLE
Fix: Open book details in same tab from image view

### DIFF
--- a/src/app/components/ImageItem.js
+++ b/src/app/components/ImageItem.js
@@ -1,5 +1,6 @@
 // src/app/components/ImageItem.js
 import Image from 'next/image'; // Using next/image for optimization
+import Link from 'next/link'; // Import Link from next/link
 
 const ImageItem = ({ item }) => {
   const { title, imageUrl, linkUrl } = item;
@@ -32,9 +33,9 @@ const ImageItem = ({ item }) => {
 
   if (linkUrl) {
     return (
-      <a href={linkUrl} target="_blank" rel="noopener noreferrer" className="block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 rounded-lg">
+      <Link href={linkUrl} className="block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 rounded-lg">
         {content}
-      </a>
+      </Link>
     );
   }
 


### PR DESCRIPTION
Modified ImageItem.js to use Next.js Link component instead of an anchor tag with target='_blank'. This ensures that clicking a book in the image view navigates to the details page in the same browser tab, consistent with the list view behavior.