### PR TITLE
Refactor: Remove 'Book Appearances' column from Villains page

### DIFF
--- a/src/app/pages/villains/VillainListClient.js
+++ b/src/app/pages/villains/VillainListClient.js
@@ -18,8 +18,7 @@ export default function VillainListClient({ initialVillains }) {
 
   const villainColumns = [
     { key: 'name', label: 'Name', isLink: true },
-    { key: 'statusDisplay', label: 'Status' },
-    { key: 'appearances', label: 'Book Appearances' }
+    { key: 'statusDisplay', label: 'Status' }
   ];
 
   const uniqueStatuses = useMemo(() => {


### PR DESCRIPTION
This commit removes the 'Book Appearances' column from the main villains listing page (`/pages/villains`). This change is intended to simplify the table view on the main list.

The 'Book Appearances' information remains available on individual villain detail pages (`/pages/villains/[id]`).