### PR TITLE
Refactor: Implement theme-aware link colors and hover effects

### DIFF
--- a/src/app/components/BookCarousel.js
+++ b/src/app/components/BookCarousel.js
@@ -46,7 +46,7 @@ const BookCarousel = () => {
   }
 
   if (error) {
-    return <div className="text-center p-10 text-red-500">Error loading books: {error}</div>;
+    return <div className="text-center p-10 text-[var(--accent-color)]">Error loading books: {error}</div>;
   }
 
   if (books.length === 0) {
@@ -73,8 +73,8 @@ const BookCarousel = () => {
                     className="object-contain rounded-lg shadow-lg"
                   />
                 ) : (
-                  <div className="w-32 h-48 bg-gray-200 flex items-center justify-center rounded-lg shadow-lg">
-                    <span className="text-xs text-gray-500">No Image</span>
+                   <div className="w-32 h-48 bg-[var(--sk-shadow-light)] dark:bg-[var(--sk-shadow-dark)] flex items-center justify-center rounded-lg shadow-lg">
+                     <span className="text-xs text-[var(--text-color)] opacity-70">No Image</span>
                   </div>
                 )}
                 <p className="mt-2 text-center text-sm font-semibold">{book.volumeInfo.title}</p>

--- a/src/app/components/ContentDisplay.js
+++ b/src/app/components/ContentDisplay.js
@@ -4,17 +4,17 @@ import ImageItem from './ImageItem';
 
 const ContentDisplay = ({ items, view = 'list', columns = [] }) => { // Added columns prop
   if (!items || items.length === 0) {
-    return <p className="text-gray-500 dark:text-gray-400 text-center py-8">No items to display.</p>;
+    return <p className="text-[var(--text-color)] opacity-70 text-center py-8">No items to display.</p>;
   }
 
   if (view === 'list') {
     if (columns.length === 0) {
-      return <p className="text-red-500 text-center py-8">List view selected, but no column definitions provided.</p>;
+      return <p className="text-[var(--accent-color)] text-center py-8">List view selected, but no column definitions provided.</p>;
     }
     return (
       <div className="overflow-x-auto shadow-md sm:rounded-lg">
-        <table className="min-w-full w-full text-left text-sm text-gray-500 dark:text-gray-400">
-          <thead className="text-xs text-gray-700 uppercase bg-gray-100 dark:bg-gray-700 border-b-2 border-red-500">
+        <table className="min-w-full w-full text-left text-sm text-[var(--text-color)] opacity-90">
+          <thead className="text-xs text-[var(--text-color)] uppercase bg-[var(--sk-row-bg-even-light)] dark:bg-[var(--sk-row-bg-even-dark)] border-b-2 border-[var(--accent-color)]">
             <tr>
               {columns.map((col) => (
                 <th scope="col" key={col.key} className="px-6 py-3">
@@ -23,7 +23,7 @@ const ContentDisplay = ({ items, view = 'list', columns = [] }) => { // Added co
               ))}
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+          <tbody className="divide-y divide-[var(--sk-shadow-light)] dark:divide-[var(--sk-shadow-dark)]">
             {items.map((item, index) => ( 
               <ListItem 
                 key={item.id || item.title || index} 
@@ -49,7 +49,7 @@ const ContentDisplay = ({ items, view = 'list', columns = [] }) => { // Added co
     );
   }
 
-  return <p className="text-red-500">Unknown view type selected.</p>;
+  return <p className="text-[var(--accent-color)]">Unknown view type selected.</p>;
 };
 
 export default ContentDisplay;

--- a/src/app/components/ImageItem.js
+++ b/src/app/components/ImageItem.js
@@ -6,18 +6,18 @@ const ImageItem = ({ item }) => {
   const { title, imageUrl, linkUrl } = item;
 
   const content = (
-    <div className="group relative aspect-[3/4] w-full bg-gray-100 dark:bg-gray-800 rounded-lg overflow-hidden shadow-md hover:shadow-xl transition-shadow duration-300">
+    <div className="group relative aspect-[3/4] w-full bg-[var(--background-color)] border border-[var(--border-color)] rounded-lg overflow-hidden shadow-md hover:shadow-xl transition-shadow duration-300">
       {imageUrl ? (
         <Image
           src={imageUrl}
           alt={title || 'Item image'}
           layout="fill"
           objectFit="cover"
-          className="bg-gray-200 dark:bg-gray-700 transition-transform duration-300 group-hover:scale-105"
+          className="bg-[var(--sk-shadow-light)] dark:bg-[var(--sk-shadow-dark)] transition-transform duration-300 group-hover:scale-105"
         />
       ) : (
-        <div className="w-full h-full flex items-center justify-center bg-gray-200 dark:bg-gray-700">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-12 h-12 text-gray-400 dark:text-gray-500">
+        <div className="w-full h-full flex items-center justify-center bg-[var(--sk-shadow-light)] dark:bg-[var(--sk-shadow-dark)]">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-12 h-12 text-[var(--text-color)] opacity-50">
             <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" /> {/* Simple X as placeholder */}
           </svg>
         </div>
@@ -33,7 +33,7 @@ const ImageItem = ({ item }) => {
 
   if (linkUrl) {
     return (
-      <Link href={linkUrl} className="block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 rounded-lg">
+      <Link href={linkUrl} className="block focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[var(--accent-color)] rounded-lg">
         {content}
       </Link>
     );

--- a/src/app/components/ListItem.js
+++ b/src/app/components/ListItem.js
@@ -5,30 +5,29 @@ const ListItem = ({ item, columns, rowIndex }) => {
   if (!columns || columns.length === 0) {
     return (
       <tr className="border-b dark:border-gray-700"> {/* Fallback border if not in a proper table */}
-        <td colSpan={100} className="px-6 py-4 text-red-500 text-center">Column definitions missing for ListItem.</td>
+        <td colSpan={100} className="px-6 py-4 text-[var(--accent-color)] text-center">Column definitions missing for ListItem.</td>
       </tr>
     );
   }
 
   const isEvenRow = rowIndex % 2 === 0;
   // Zebra striping for content rows.
-  // Light theme: even rows white, odd rows gray-50.
-  // Dark theme: even rows gray-800, odd rows gray-900.
-  // Hover states are slightly darker than the non-hover state of the OTHER stripe color for better contrast.
+  // Zebra striping for content rows.
+  // Uses CSS variables for theme-awareness.
   const rowClasses = `
-    ${isEvenRow ? 'bg-white dark:bg-gray-800' : 'bg-gray-50 dark:bg-gray-900'} 
-    hover:bg-gray-200 dark:hover:bg-gray-700 
+    ${isEvenRow ? 'bg-[var(--row-bg-even)]' : 'bg-[var(--row-bg-odd)]'}
+    hover:bg-[var(--row-hover-bg)] hover:text-[var(--text-on-accent)]
     transition-colors duration-150
   `;
 
   return (
     <tr className={rowClasses.trim()}>
       {columns.map((col) => (
-        <td key={col.key} className="px-6 py-4 text-gray-700 dark:text-gray-300 whitespace-normal align-top"> {/* Added align-top for consistency if cell content varies in height */}
+        <td key={col.key} className="px-6 py-4 text-[var(--text-color)] whitespace-normal align-top"> {/* Added align-top for consistency if cell content varies in height */}
           {typeof col.render === 'function' ? (
             col.render(item) // Use custom render function
           ) : col.isLink && item.linkUrl ? ( // Fallback to default link rendering for the designated 'isLink' column
-            <Link href={item.linkUrl} className="hover:underline text-indigo-600 dark:text-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-300 rounded">
+            <Link href={item.linkUrl} className="hover:underline text-[var(--link-color)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-color)] rounded">
               {String(item[col.key] ?? '-')}
             </Link>
           ) : ( // Fallback to default text rendering

--- a/src/app/components/PageLinks.js
+++ b/src/app/components/PageLinks.js
@@ -5,25 +5,25 @@ export default function PageLinks({ pageLinks }) {
     <div className="w-full max-w-2xl mt-8">
       <div className="space-y-8"> {/* Increased spacing for better readability */}
         {pageLinks.map((link) => (
-          <div key={link.title} className="flex flex-col items-start p-4 rounded-lg shadow-lg bg-gray-800 bg-opacity-50 hover:shadow-xl transition-shadow duration-300 ease-in-out">
+          <div key={link.title} className="flex flex-col items-start p-4 rounded-lg shadow-lg bg-[var(--details-box-bg)] bg-opacity-80 hover:shadow-xl transition-shadow duration-300 ease-in-out">
             {link.isExternal ? (
               <a
                 href={link.href}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-3xl font-bold text-[var(--link-color)] hover:text-[var(--link-hover-color)] no-underline hover:underline" // Title style
+                className="text-3xl font-bold text-[var(--link-color)] hover:text-[var(--hover-accent-color)] no-underline hover:underline" // Title style
               >
                 {link.title} <span className="text-lg opacity-75">(Official Site)</span>
               </a>
             ) : (
               <Link
                 href={link.href}
-                className="text-3xl font-bold text-[var(--link-color)] hover:text-[var(--link-hover-color)] no-underline hover:underline" // Title style
+                className="text-3xl font-bold text-[var(--link-color)] hover:text-[var(--hover-accent-color)] no-underline hover:underline" // Title style
               >
                 {link.title}
               </Link>
             )}
-            <p className="text-md text-gray-300 mt-2"> {/* Summary text style */}
+            <p className="text-md text-[var(--text-color)] opacity-90 mt-2"> {/* Summary text style */}
               {link.summary}
             </p>
             {/* "Visit page" link */}
@@ -32,14 +32,14 @@ export default function PageLinks({ pageLinks }) {
                 href={link.href}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="mt-4 text-lg text-[var(--link-color)] hover:text-[var(--link-hover-color)] underline"
+                className="mt-4 text-lg text-[var(--link-color)] hover:text-[var(--hover-accent-color)] underline"
               >
                 Visit Site
               </a>
             ) : (
               <Link
                 href={link.href}
-                className="mt-4 text-lg text-[var(--link-color)] hover:text-[var(--link-hover-color)] underline"
+                className="mt-4 text-lg text-[var(--link-color)] hover:text-[var(--hover-accent-color)] underline"
               >
                 Visit Page
               </Link>

--- a/src/app/components/SearchAndSortControls.js
+++ b/src/app/components/SearchAndSortControls.js
@@ -58,7 +58,7 @@ export default function SearchAndSortControls({
             <button
               key={option.key}
               onClick={() => onRequestSort(option.key)}
-              className="flex items-center px-3 py-2 text-sm border border-[var(--button-border)] rounded-md hover:bg-[var(--button-hover-background)] text-[var(--button-text)] bg-[var(--button-background)] transition-colors"
+              className="flex items-center px-3 py-2 text-sm border border-[var(--button-border)] rounded-md hover:bg-[var(--button-hover-background)] hover:text-[var(--text-on-accent)] text-[var(--button-text)] bg-[var(--button-background)] transition-colors"
             >
               {option.label} {getSortLabel(option)}
               {getSortIcon(option.key)}

--- a/src/app/components/ViewSwitcher.js
+++ b/src/app/components/ViewSwitcher.js
@@ -3,9 +3,11 @@ import ListViewIcon from './icons/ListViewIcon';
 import GridViewIcon from './icons/GridViewIcon';
 
 const ViewSwitcher = ({ currentView, onViewChange }) => {
-  const commonButtonClasses = "p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500";
-  const activeButtonClasses = "bg-indigo-100 text-indigo-700 dark:bg-indigo-700 dark:text-indigo-100";
-  const inactiveButtonClasses = "text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200";
+  const commonButtonClasses = "p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[var(--accent-color)]";
+  // Active button uses new theme variables
+  const activeButtonClasses = "bg-[var(--control-active-bg)] text-[var(--control-active-text)]";
+  // Inactive button uses theme variables for text and kitab button hover for background
+  const inactiveButtonClasses = "text-[var(--text-color)] opacity-70 hover:bg-[var(--hover-accent-color)] hover:text-[var(--text-on-accent)]";
   const iconClasses = "w-6 h-6";
 
   return (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -38,8 +38,8 @@
   --nav-link-focus-ring-light: var(--sk-accent-light);
 
   /* Navigation Link Hover Background (using accent) */
-  --nav-link-hover-bg-dark: var(--sk-hover-accent-dark);
-  --nav-link-hover-bg-light: var(--sk-hover-accent-light);
+  --nav-link-hover-bg-dark: #FFFFFF; /* Changed to white */
+  --nav-link-hover-bg-light: #FFFFFF; /* Changed to white */
 
 
   /* Map Marker colors - can be adapted or kept generic if SK site doesn't have maps */
@@ -57,13 +57,34 @@
   --kitab-button-background-light: #FFFFFF; /* White background */
   --kitab-button-text-light: #000000;       /* Black text */
   --kitab-button-border-light: #000000;     /* Black border */
-  --kitab-button-hover-background-light: #f0f0f0; /* Light gray hover */
+  --kitab-button-hover-background-light: var(--sk-hover-accent-light); /* Changed to accent */
 
   /* Button specific styles for dark theme */
   --kitab-button-background-dark: #000000;  /* Black background */
   --kitab-button-text-dark: #FFFFFF;        /* White text */
   --kitab-button-border-dark: #FFFFFF;      /* White border */
-  --kitab-button-hover-background-dark: #333333;  /* Dark gray hover */
+  --kitab-button-hover-background-dark: var(--sk-hover-accent-dark);  /* Changed to accent */
+
+  /* Link colors */
+  --sk-link-dark: var(--sk-text-dark); /* White for dark theme */
+  --sk-link-light: var(--sk-text-light); /* Black for light theme */
+
+  /* Border color */
+  --sk-border-dark: var(--sk-shadow-dark); /* Using shadow color for borders */
+  --sk-border-light: var(--sk-shadow-light); /* Using shadow color for borders */
+
+  /* List Row Hover colors */
+  --sk-row-hover-light: var(--sk-hover-accent-light); /* Changed to accent */
+  --sk-row-hover-dark: var(--sk-hover-accent-dark);   /* Changed to accent */
+
+  /* Control Active State colors */
+  --sk-control-active-bg-light: #e0e7ff; /* Light Indigo */
+  --sk-control-active-text-light: #3730a3; /* Dark Indigo */
+  --sk-control-active-bg-dark: #4338ca; /* Indigo */
+  --sk-control-active-text-dark: #c7d2fe; /* Light Indigo */
+
+  /* Text color for on-accent backgrounds */
+  --text-on-accent: #FFFFFF;
 }
 
 /* Default to dark theme */
@@ -99,6 +120,11 @@ body {
   --kitab-button-text: var(--kitab-button-text-dark);
   --kitab-button-border: var(--kitab-button-border-dark);
   --kitab-button-hover-background: var(--kitab-button-hover-background-dark);
+  --link-color: var(--sk-link-dark);
+  --border-color: var(--sk-border-dark);
+  --row-hover-bg: var(--sk-row-hover-dark);
+  --control-active-bg: var(--sk-control-active-bg-dark);
+  --control-active-text: var(--sk-control-active-text-dark);
 
   color: var(--text-color);
   background: var(--background-color);
@@ -139,6 +165,11 @@ body {
     --kitab-button-text: var(--kitab-button-text-light);
     --kitab-button-border: var(--kitab-button-border-light);
     --kitab-button-hover-background: var(--kitab-button-hover-background-light);
+  --link-color: var(--sk-link-light);
+  --border-color: var(--sk-border-light);
+  --row-hover-bg: var(--sk-row-hover-light);
+  --control-active-bg: var(--sk-control-active-bg-light);
+  --control-active-text: var(--sk-control-active-text-light);
 
     color: var(--text-color);
     background: var(--background-color);
@@ -224,6 +255,18 @@ body {
   0% { opacity: 0.05; }
   50% { opacity: 0.15; }
   100% { opacity: 0.05; }
+}
+
+/* Generic link styling */
+a {
+  color: var(--link-color);
+  text-decoration: none; /* Optional: remove underline by default */
+  /* transition: color 0.2s ease-in-out; */ /* Optional: keep if only color changes */
+}
+
+a:hover {
+  color: var(--hover-accent-color);
+  text-decoration: underline;
 }
 
 /* Apply the animation to the body's pseudo-element */

--- a/src/app/pages/about-stephen-king/page.js
+++ b/src/app/pages/about-stephen-king/page.js
@@ -22,7 +22,7 @@ const AboutStephenKing = () => {
               height={375}
               className="rounded-lg shadow-lg mx-auto md:mx-0"
             />
-            <figcaption className="text-center text-sm mt-2 text-gray-600">
+            <figcaption className="text-center text-sm mt-2 text-[var(--text-color)] opacity-80">
               Stephen King in 2024. Image from Wikipedia.
             </figcaption>
           </figure>
@@ -40,14 +40,13 @@ const AboutStephenKing = () => {
         </div>
       </div>
       </div> {/* Closing details-box div */}
-      <div className="mt-8 pt-4 border-t border-gray-300 text-center">
+      <div className="mt-8 pt-4 border-t border-[var(--border-color)] text-center">
         <p className="text-md mb-2">
           For more information, visit the{' '}
           <a
             href="https://en.wikipedia.org/wiki/Stephen_King"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-blue-500 hover:underline"
           >
             Stephen King Wikipedia page
           </a>
@@ -59,7 +58,6 @@ const AboutStephenKing = () => {
             href="https://stephenking.com"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-blue-500 hover:underline"
           >
             StephenKing.com
           </a>

--- a/src/app/pages/adapted-works/AdaptedWorksListClient.js
+++ b/src/app/pages/adapted-works/AdaptedWorksListClient.js
@@ -20,10 +20,10 @@ export default function AdaptedWorksListClient({ adaptations: initialAdaptations
       label: 'Based On',
       render: (item) => {
         if (!item.originalWorkTitle) {
-          return <span className="text-gray-500 dark:text-gray-400">-</span>;
+          return <span className="text-[var(--text-color)] opacity-70">-</span>;
         }
         if (item.originalWorkLink) {
-          const commonLinkClasses = "hover:underline text-sky-600 dark:text-sky-400";
+          const commonLinkClasses = "hover:underline"; // Link color will be inherited from global 'a'
           if (item.originalWorkLink.startsWith('/')) {
             return (
               <Link href={item.originalWorkLink} className={commonLinkClasses}>
@@ -32,10 +32,10 @@ export default function AdaptedWorksListClient({ adaptations: initialAdaptations
             );
           } else if (item.originalWorkLink.startsWith('http')) {
             return (
-              <a 
-                href={item.originalWorkLink} 
-                target="_blank" 
-                rel="noopener noreferrer" 
+              <a
+                href={item.originalWorkLink}
+                target="_blank"
+                rel="noopener noreferrer"
                 className={commonLinkClasses}
               >
                 {item.originalWorkTitle}

--- a/src/app/pages/books/[id]/page.js
+++ b/src/app/pages/books/[id]/page.js
@@ -35,7 +35,7 @@ export default async function BookDetailPage({ params }) {
       <div className="container mx-auto p-4 py-8 text-center">
         <h1 className="text-3xl font-bold text-[var(--accent-color)] mb-4">Book Not Found</h1>
         <p className="text-[var(--text-color)] mb-6">Sorry, we couldn&apos;t find the book you were looking for.</p>
-        <Link href="/pages/books" className="inline-block bg-[var(--accent-color)] hover:bg-[var(--hover-accent-color)] text-white font-semibold py-2 px-4 rounded shadow transition-colors">
+        <Link href="/pages/books" className="inline-block bg-[var(--accent-color)] hover:bg-[var(--hover-accent-color)] text-[var(--sk-text-dark)] font-semibold py-2 px-4 rounded shadow transition-colors">
           Back to Books List
         </Link>
       </div>
@@ -56,7 +56,7 @@ export default async function BookDetailPage({ params }) {
 
   return (
     <div className="container mx-auto p-4 md:p-8">
-      <Link href="/pages/books" className="text-blue-500 hover:underline mb-6 inline-block">
+      <Link href="/pages/books" className="mb-6 inline-block">
           &larr; Back to Books List
         </Link>
       <div className="details-box">
@@ -73,7 +73,7 @@ export default async function BookDetailPage({ params }) {
                   priority
                 />
               ) : (
-                <div className="w-full h-full flex items-center justify-center bg-gray-200 dark:bg-gray-700 text-gray-500 dark:text-gray-400 rounded-lg shadow-md">
+                <div className="w-full h-full flex items-center justify-center bg-[var(--sk-shadow-light)] dark:bg-[var(--sk-shadow-dark)] text-[var(--text-color)] opacity-70 rounded-lg shadow-md">
                   No Cover Available
                 </div>
               )}
@@ -82,10 +82,10 @@ export default async function BookDetailPage({ params }) {
 
         <div className="md:w-2/3 md:pl-8">
           <h1 className="text-3xl md:text-4xl font-bold text-[var(--accent-color)] mb-2">{book.Title}</h1>
-          {book.subtitle && <p className="text-xl text-gray-600 dark:text-gray-400 mb-3">{book.subtitle}</p>}
+          {book.subtitle && <p className="text-xl text-[var(--text-color)] opacity-80 mb-3">{book.subtitle}</p>}
 
           {book.authors && book.authors.length > 0 && (
-            <p className="text-lg text-gray-700 dark:text-gray-300 mb-4">
+            <p className="text-lg text-[var(--text-color)] mb-4">
               By: <span className="font-medium">{book.authors.join(', ')}</span>
             </p>
           )}
@@ -139,7 +139,7 @@ export default async function BookDetailPage({ params }) {
       </div>
 
       {filteredNotes.length > 0 && (
-        <div className="mt-8 pt-6 border-t border-gray-300 dark:border-gray-600">
+        <div className="mt-8 pt-6 border-t border-[var(--border-color)]">
           <h2 className="text-2xl font-semibold text-[var(--accent-color)] mb-3">Notes</h2>
           <ul className="list-disc pl-5 space-y-1 text-sm">
             {filteredNotes.map((note, index) => (
@@ -150,7 +150,7 @@ export default async function BookDetailPage({ params }) {
       )}
 
       {book.villains && book.villains.length > 0 && (
-        <div className="mt-8 pt-6 border-t border-gray-300 dark:border-gray-600">
+        <div className="mt-8 pt-6 border-t border-[var(--border-color)]">
           <h2 className="text-2xl font-semibold text-[var(--accent-color)] mb-3">Villains in this Book</h2>
           <ul className="list-disc pl-5 space-y-1">
             {book.villains.map(villain => {
@@ -178,7 +178,7 @@ export default async function BookDetailPage({ params }) {
         </div>
       )}
       {(!book.villains || book.villains.length === 0) && bookData?.data && (
-        <div className="mt-8 pt-6 border-t border-gray-300 dark:border-gray-600">
+        <div className="mt-8 pt-6 border-t border-[var(--border-color)]">
           <h2 className="text-2xl font-semibold text-[var(--accent-color)] mb-3">Villains in this Book</h2>
           <p className="text-sm">No villains listed for this book.</p>
         </div>

--- a/src/app/pages/shorts/[id]/page.js
+++ b/src/app/pages/shorts/[id]/page.js
@@ -31,7 +31,7 @@ export default async function ShortStoryDetailPage({ params }) {
 
   return (
     <div className="container mx-auto p-4">
-      <Link href="/pages/shorts" className="text-blue-500 hover:underline mb-6 inline-block">
+      <Link href="/pages/shorts" className="mb-6 inline-block">
         &larr; Back to Shorts List
       </Link>
       <div className="details-box">

--- a/src/app/pages/villains/[id]/VillainBookAppearances.js
+++ b/src/app/pages/villains/[id]/VillainBookAppearances.js
@@ -47,7 +47,7 @@ export default function VillainBookAppearances({ books = [], shorts = [] }) {
       <ul className="list-disc pl-5">
         {appearances.map(appearance => (
           <li key={appearance.id} className="mb-1">
-            <Link href={appearance.href} className="text-blue-600 hover:underline">
+            <Link href={appearance.href} className="">
               {appearance.title}
             </Link>
             {` (${appearance.type})`}

--- a/src/app/pages/villains/[id]/page.js
+++ b/src/app/pages/villains/[id]/page.js
@@ -20,14 +20,14 @@ export default async function VillainDetailPage({ params }) {
 
   return (
     <div className="container mx-auto p-4">
-      <Link href="/pages/villains" className="text-blue-500 hover:underline mb-6 inline-block">
+      <Link href="/pages/villains" className="mb-6 inline-block">
             &larr; Back to Villains List
           </Link>
       <div className="details-box">
         <div className="md:flex md:space-x-6"> {/* Flex container for medium screens and up */}
           {/* Image Placeholder (Left Column on MD+) */}
           <div className="md:w-1/3 mb-4 md:mb-0"> {/* Takes 1/3 width on medium screens, full on small */}
-            <div className="relative w-full aspect-[4/3] bg-neutral-700 overflow-hidden rounded-lg flex items-center justify-center">
+            <div className="relative w-full aspect-[4/3] bg-[var(--sk-shadow-light)] dark:bg-[var(--sk-shadow-dark)] overflow-hidden rounded-lg flex items-center justify-center">
               {villain.image_url ? (
                 <Image
                   src={villain.image_url}
@@ -37,7 +37,7 @@ export default async function VillainDetailPage({ params }) {
                   className="rounded-lg"
                 />
               ) : (
-                <div className="w-full h-full flex items-center justify-center text-neutral-500 text-sm">
+                <div className="w-full h-full flex items-center justify-center text-[var(--text-color)] opacity-70 text-sm">
                   No image available
                 </div>
               )}


### PR DESCRIPTION
- Updated globals.css to define light and dark theme link colors (black/white respectively).
- Standardized component and page styles to use these global theme variables, removing hardcoded colors and Tailwind classes for theme-related properties (excluding Google Books pages per user instruction).
- Defined CSS variables for various element states (borders, row hover, active controls, button hovers).
- Refined hover effects based on user feedback:
  - NavigationBar links: White background on hover, default link text color.
  - Plain text links: Accent color text and underline on hover.
  - List items & specific buttons (ViewSwitcher, Kitab): Accent color background with white text on hover.