### PR TITLE
I've updated the list item hover color to a neutral gray.

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -76,8 +76,9 @@
   --sk-border-light: var(--sk-shadow-light); /* Using shadow color for borders */
 
   /* List Row Hover colors */
-  --sk-row-hover-light: var(--sk-hover-accent-light); /* Changed to accent */
-  --sk-row-hover-dark: var(--sk-hover-accent-dark);   /* Changed to accent */
+  --sk-row-hover-neutral-gray: #808080; /* Neutral gray for row hover */
+  --sk-row-hover-light: var(--sk-row-hover-neutral-gray);
+  --sk-row-hover-dark: var(--sk-row-hover-neutral-gray);
 
   /* Control Active State colors */
   --sk-control-active-bg-light: #e0e7ff; /* Light Indigo */


### PR DESCRIPTION
I changed the hover background color for list items to a medium gray (#808080) that works in both light and dark themes. The hover text color remains white for good contrast.

This was achieved by:
- Defining a new CSS variable `--sk-row-hover-neutral-gray: #808080` in `global.css`.
- Updating `--sk-row-hover-light` and `--sk-row-hover-dark` to use this new variable.
- `ListItem.js` already used the appropriate CSS variables, so no changes were needed there.