### PR TITLE
Fix: Prevent infinite loop in BookCarousel image onError

### DIFF
--- a/src/app/components/BookCarousel.js
+++ b/src/app/components/BookCarousel.js
@@ -86,7 +86,10 @@ const BookCarousel = () => {
                   className="home-carousel-image"
                   style={{ objectFit: 'contain' }}
                   onError={(e) => {
-                    e.currentTarget.src = `https://via.placeholder.com/200x300.png?text=${encodeURIComponent(book.Title || "Book Cover")}+Error`;
+                    // Prevent infinite loop if placeholder itself fails
+                    if (!e.currentTarget.src.includes('via.placeholder.com')) {
+                      e.currentTarget.src = `https://via.placeholder.com/200x300.png?text=${encodeURIComponent(book.Title || "Book Cover")}+Error`;
+                    }
                   }}
                 />
                 <div className="home-carousel-caption">{book.Title}</div>


### PR DESCRIPTION
I modified the onError handler in the BookCarousel component to check if the image source is already a placeholder URL before attempting to set it again. This prevents a potential infinite loop if the placeholder image itself fails to load.