### PR TITLE
Refactor: Move book data fetching to API route

### DIFF
--- a/src/app/api/books/carousel/route.js
+++ b/src/app/api/books/carousel/route.js
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import OriginalRequest from '../../../components/request'; // Adjust path as necessary
+
+const MAX_CAROUSEL_BOOKS = 10;
+
+export async function GET() {
+  try {
+    // Call the original Request function, ensuring it runs server-side
+    // The 'books' parameter is what BookCarousel was using
+    const response = await OriginalRequest('books');
+
+    if (response.error) {
+      // Log the error server-side
+      console.error("Error fetching books for carousel API:", response.error);
+      // Return a generic error to the client
+      return NextResponse.json({ error: 'Failed to load books' }, { status: 500 });
+    }
+
+    if (response.data && Array.isArray(response.data)) {
+      // Select a subset of books for the carousel, similar to BookCarousel's original logic
+      const carouselBooks = response.data.slice(0, MAX_CAROUSEL_BOOKS);
+      return NextResponse.json(carouselBooks);
+    } else {
+      // This case should ideally be handled within OriginalRequest or result in an error there
+      console.warn("Carousel API: No data or data is not an array from OriginalRequest.");
+      return NextResponse.json([]); // Return empty array if no books
+    }
+  } catch (e) {
+    console.error("Critical error in /api/books/carousel:", e);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/components/BookCarousel.js
+++ b/src/app/components/BookCarousel.js
@@ -3,9 +3,10 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
-import Request from './request'; // Import the Request component
+// Request component is no longer directly used here
 
-const MAX_CAROUSEL_BOOKS = 10;
+// MAX_CAROUSEL_BOOKS is handled by the API route, but can be kept for consistency if needed
+// const MAX_CAROUSEL_BOOKS = 10;
 
 const BookCarousel = () => {
   const [books, setBooks] = useState([]);
@@ -17,18 +18,22 @@ const BookCarousel = () => {
     const fetchCarouselBooks = async () => {
       setLoading(true);
       try {
-        const response = await Request('books'); // Use Request component to fetch all books
-        if (response.error) {
-          throw new Error(response.error);
+        // Fetch from the new API route
+        const response = await fetch('/api/books/carousel');
+        if (!response.ok) {
+          // Try to parse error message from response body if available
+          let errorMsg = `HTTP error ${response.status}`;
+          try {
+            const errorData = await response.json();
+            errorMsg = errorData.error || errorMsg;
+          } catch (parseError) {
+            // Ignore if response is not JSON or empty
+          }
+          throw new Error(errorMsg);
         }
-        if (response.data && Array.isArray(response.data)) {
-          // Select a subset of books for the carousel, e.g., the first MAX_CAROUSEL_BOOKS
-          // Optionally, add randomization or curation logic here
-          const carouselBooks = response.data.slice(0, MAX_CAROUSEL_BOOKS);
-          setBooks(carouselBooks);
-        } else {
-          setBooks([]); // Set to empty array if no data or data is not an array
-        }
+        const data = await response.json();
+        // The API route now returns the already sliced and processed books
+        setBooks(data);
       } catch (e) {
         setError(e.message);
         console.error("Failed to fetch books for carousel:", e);
@@ -86,7 +91,10 @@ const BookCarousel = () => {
                   className="home-carousel-image"
                   style={{ objectFit: 'contain' }}
                   onError={(e) => {
-                    e.currentTarget.src = `https://via.placeholder.com/200x300.png?text=${encodeURIComponent(book.Title || "Book Cover")}+Error`;
+                    // Prevent infinite loop if placeholder itself fails
+                    if (!e.currentTarget.src.includes('via.placeholder.com')) {
+                      e.currentTarget.src = `https://via.placeholder.com/200x300.png?text=${encodeURIComponent(book.Title || "Book Cover")}+Error`;
+                    }
                   }}
                 />
                 <div className="home-carousel-caption">{book.Title}</div>


### PR DESCRIPTION
- I created a new API route `/api/books/carousel` to handle fetching and processing book data for your homepage carousel.
- I modified `BookCarousel.js` to fetch data from this new API route.
- This ensures that the `GOOGLE_BOOKS_API_KEY` is accessed on the server-side, resolving issues with warnings about the missing key and potential 400 errors from Google Books API when called from client-side.
- The original `request.js` logic is now invoked server-side via the API route.