### PR TITLE
Align Home page spacing with Books page

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -34,7 +34,7 @@ export default function Page() {
   // carouselItemsData is no longer needed here as BookCarousel fetches its own data.
 
   return (
-    <>
+    <div className="w-full md:w-3/4 md:mx-auto px-4 md:px-0">
       <header className="home-header">
         <h1>Stephen King Universe</h1>
       </header>
@@ -46,6 +46,6 @@ export default function Page() {
       <footer className="home-footer">
         &copy; {new Date().getFullYear()} Stephen King Universe Fan Page. All rights reserved.
       </footer>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
I wrapped the main content of the Home page (src/app/page.js) in a new div. I applied Tailwind classes 'w-full md:w-3/4 md:mx-auto px-4 md:px-0' to this div. This change ensures that the Home page's main content area has consistent width, centering, and responsive padding behavior compared to the Books page's content area.

Note: Existing Jest tests are failing. These failures appear to be unrelated to the changes made in this commit, which were confined to src/app/page.js for layout adjustment.