### PR TITLE
feat: Implement API caching and data backup script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest"
+    "test": "jest",
+    "backup-data": "node scripts/backupData.js"
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.1.10",

--- a/scripts/backupData.js
+++ b/scripts/backupData.js
@@ -1,0 +1,39 @@
+import fs from 'fs';
+import path from 'path';
+import Request from '../src/app/components/request.js'; // Adjust path as necessary
+
+const DATA_DIR = path.join(process.cwd(), 'src', 'app', 'data'); // process.cwd() gives the root of the project
+
+async function backupData() {
+  const endpoints = ['villains', 'shorts', 'books'];
+  const backupPromises = endpoints.map(async (endpoint) => {
+    try {
+      console.log(`[INFO] Backup: Fetching data for ${endpoint}...`);
+      const response = await Request(endpoint);
+      if (response.error) {
+        console.error(`[ERROR] Backup: Failed to fetch data for ${endpoint}: ${response.error}`);
+        return;
+      }
+      if (!response || !response.data) {
+        console.error(`[ERROR] Backup: No data received for ${endpoint}.`);
+        return;
+      }
+
+      const filePath = path.join(DATA_DIR, `${endpoint}.json`);
+      fs.writeFileSync(filePath, JSON.stringify(response.data, null, 2));
+      console.log(`[INFO] Backup: Successfully backed up ${endpoint} to ${filePath}`);
+    } catch (error) {
+      console.error(`[ERROR] Backup: Error processing ${endpoint}: ${error.message}`, error);
+    }
+  });
+
+  await Promise.all(backupPromises);
+  console.log('[INFO] Backup: Data backup process completed.');
+}
+
+// Create data directory if it doesn't exist
+if (!fs.existsSync(DATA_DIR)) {
+  fs.mkdirSync(DATA_DIR, { recursive: true });
+}
+
+backupData();

--- a/src/app/components/request.js
+++ b/src/app/components/request.js
@@ -1,6 +1,15 @@
 let apiKeyWarningLogged = false; // Module-scoped flag
+const cache = new Map(); // In-memory cache
 
 export default async function Request(parameter, options = {}) {
+    // Check cache first
+    if (cache.has(parameter)) {
+        // console.log(`[INFO] Request: Cache hit for parameter: "${parameter}"`);
+        return cache.get(parameter);
+    }
+
+    // console.log(`[INFO] Request: Cache miss for parameter: "${parameter}". Fetching from API.`);
+
     // skipGoogleBooks option removed, we will always try to augment book data.
     // Use GOOGLE_BOOKS_API_KEY (server-side environment variable)
     const apiKey = process.env.GOOGLE_BOOKS_API_KEY;
@@ -144,8 +153,12 @@ export default async function Request(parameter, options = {}) {
         await Promise.all(processPromises);
         // console.log(`[INFO] Request: Google Books API calls completed for "${parameter}". ${booksProcessedCount} items processed.`);
       }
+      // Store successful response in cache
+      // console.log(`[INFO] Request: Storing successful response for "${parameter}" in cache.`);
+      cache.set(parameter, data);
     } catch (err) {
       console.error(`[ERROR] Request: Top-level error for "${parameter}": ${err.message}`, err);
+      // Do not cache errors, return them directly
       return { data: null, error: err.message }; // Ensure a consistent error structure
     }
     // console.log(`[INFO] Request: Finished for "${parameter}"`);

--- a/src/app/data/books.json
+++ b/src/app/data/books.json
@@ -1,0 +1,1573 @@
+[
+  {
+    "id": 1,
+    "Year": 1974,
+    "Title": "Carrie",
+    "handle": "carrie",
+    "Publisher": "Doubleday",
+    "ISBN": "978-0-385-08695-0",
+    "Pages": 199,
+    "Notes": [
+      ""
+    ],
+    "created_at": "2023-11-13T23:48:47.848Z",
+    "villains": [
+      {
+        "name": "Tina Blake",
+        "url": "https://stephen-king-api.onrender.com/api/villain/4"
+      },
+      {
+        "name": "Cindi",
+        "url": "https://stephen-king-api.onrender.com/api/villain/14"
+      },
+      {
+        "name": "Myra Crewes",
+        "url": "https://stephen-king-api.onrender.com/api/villain/16"
+      },
+      {
+        "name": "Billy deLois",
+        "url": "https://stephen-king-api.onrender.com/api/villain/25"
+      },
+      {
+        "name": "Kenny Garson",
+        "url": "https://stephen-king-api.onrender.com/api/villain/38"
+      },
+      {
+        "name": "Mary Lila Grace",
+        "url": "https://stephen-king-api.onrender.com/api/villain/44"
+      },
+      {
+        "name": "Christine Hargensen",
+        "url": "https://stephen-king-api.onrender.com/api/villain/49"
+      },
+      {
+        "name": "Vic Mooney",
+        "url": "https://stephen-king-api.onrender.com/api/villain/75"
+      },
+      {
+        "name": "The Mortimer Snerds",
+        "url": "https://stephen-king-api.onrender.com/api/villain/77"
+      },
+      {
+        "name": "Billy Nolan",
+        "url": "https://stephen-king-api.onrender.com/api/villain/80"
+      },
+      {
+        "name": "Elenor Richmond",
+        "url": "https://stephen-king-api.onrender.com/api/villain/90"
+      },
+      {
+        "name": "Rachel Spies",
+        "url": "https://stephen-king-api.onrender.com/api/villain/94"
+      },
+      {
+        "name": "Jackie Talbot",
+        "url": "https://stephen-king-api.onrender.com/api/villain/99"
+      },
+      {
+        "name": "Donna and Mary Lila Grace Thibodeau",
+        "url": "https://stephen-king-api.onrender.com/api/villain/102"
+      },
+      {
+        "name": "Jessica Upshaw",
+        "url": "https://stephen-king-api.onrender.com/api/villain/108"
+      },
+      {
+        "name": "Norma Watson",
+        "url": "https://stephen-king-api.onrender.com/api/villain/109"
+      },
+      {
+        "name": "Margaret White",
+        "url": "https://stephen-king-api.onrender.com/api/villain/113"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 2,
+    "Year": 1975,
+    "Title": "Salem's Lot",
+    "handle": "salem-s-lot",
+    "Publisher": "Doubleday",
+    "ISBN": "978-0-385-00751-1",
+    "Pages": 439,
+    "Notes": [
+      "Nominee, World Fantasy Award, 1976[2]"
+    ],
+    "created_at": "2023-11-13T23:48:48.098Z",
+    "villains": [
+      {
+        "name": "Kurt Barlow",
+        "url": "https://stephen-king-api.onrender.com/api/villain/2"
+      },
+      {
+        "name": "Richard Straker",
+        "url": "https://stephen-king-api.onrender.com/api/villain/98"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 3,
+    "Year": 1977,
+    "Title": "The Shining",
+    "handle": "the-shining",
+    "Publisher": "Doubleday",
+    "ISBN": "978-0-385-12167-5",
+    "Pages": 447,
+    "Notes": [
+      "Runner-up (4th place), Locus Award for Best Fantasy Novel, 1978[2]"
+    ],
+    "created_at": "2023-11-13T23:48:48.219Z",
+    "villains": [
+      {
+        "name": "Horace M. Derwent",
+        "url": "https://stephen-king-api.onrender.com/api/villain/26"
+      },
+      {
+        "name": "Delbert Grady",
+        "url": "https://stephen-king-api.onrender.com/api/villain/45"
+      },
+      {
+        "name": "Jack Torrance",
+        "url": "https://stephen-king-api.onrender.com/api/villain/106"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 4,
+    "Year": 1977,
+    "Title": "Rage",
+    "handle": "rage",
+    "Publisher": "Signet Books",
+    "ISBN": "978-0-451-07645-8",
+    "Pages": 211,
+    "Notes": [
+      "Published under pseudonym Richard Bachman"
+    ],
+    "created_at": "2023-11-13T23:48:48.339Z",
+    "villains": [],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 5,
+    "Year": 1978,
+    "Title": "The Stand",
+    "handle": "the-stand",
+    "Publisher": "Doubleday",
+    "ISBN": "978-0-385-12168-2",
+    "Pages": 823,
+    "Notes": [
+      "Nominee, World Fantasy Award, 1979",
+      "Runner-up (15th place), Locus Award, 1979[2]"
+    ],
+    "created_at": "2023-11-13T23:48:48.477Z",
+    "villains": [
+      {
+        "name": "Donald Merwin Elbert",
+        "url": "https://stephen-king-api.onrender.com/api/villain/34"
+      },
+      {
+        "name": "Randall Flagg",
+        "url": "https://stephen-king-api.onrender.com/api/villain/37"
+      },
+      {
+        "name": "Lloyd Henreid",
+        "url": "https://stephen-king-api.onrender.com/api/villain/51"
+      },
+      {
+        "name": "The Kid",
+        "url": "https://stephen-king-api.onrender.com/api/villain/62"
+      },
+      {
+        "name": "Harold Lauder",
+        "url": "https://stephen-king-api.onrender.com/api/villain/64"
+      },
+      {
+        "name": "Rat Man",
+        "url": "https://stephen-king-api.onrender.com/api/villain/87"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 6,
+    "Year": 1979,
+    "Title": "The Long Walk",
+    "handle": "the-long-walk",
+    "Publisher": "Signet Books",
+    "ISBN": "978-0-451-08754-6",
+    "Pages": 384,
+    "Notes": [
+      "Published under pseudonym Richard Bachman"
+    ],
+    "created_at": "2023-11-13T23:48:48.608Z",
+    "villains": [
+      {
+        "name": "Randall Flagg",
+        "url": "https://stephen-king-api.onrender.com/api/villain/37"
+      },
+      {
+        "name": "The Major",
+        "url": "https://stephen-king-api.onrender.com/api/villain/70"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 7,
+    "Year": 1979,
+    "Title": "The Dead Zone",
+    "handle": "the-dead-zone",
+    "Publisher": "Viking Press",
+    "ISBN": "978-0-670-26077-5",
+    "Pages": 428,
+    "Notes": [
+      "Runner-up (2nd place), Locus Award for Best Fantasy Novel, 1980[2]"
+    ],
+    "created_at": "2023-11-13T23:48:48.753Z",
+    "villains": [
+      {
+        "name": "Frank Dodd",
+        "url": "https://stephen-king-api.onrender.com/api/villain/29"
+      },
+      {
+        "name": "Henrietta Dodd",
+        "url": "https://stephen-king-api.onrender.com/api/villain/30"
+      },
+      {
+        "name": "Malcolm Janus",
+        "url": "https://stephen-king-api.onrender.com/api/villain/71"
+      },
+      {
+        "name": "Sonny Elliman",
+        "url": "https://stephen-king-api.onrender.com/api/villain/93"
+      },
+      {
+        "name": "Greg Stillson",
+        "url": "https://stephen-king-api.onrender.com/api/villain/97"
+      },
+      {
+        "name": "The Devil's Dozen",
+        "url": "https://stephen-king-api.onrender.com/api/villain/100"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 8,
+    "Year": 1980,
+    "Title": "Firestarter",
+    "handle": "firestarter",
+    "Publisher": "Viking Press",
+    "ISBN": "978-0-670-31541-3",
+    "Pages": 426,
+    "Notes": [
+      "Nominee, British Fantasy Award’s August Derleth Award, 1981",
+      "Runner-up (8th place), Locus Award for Best Science Fiction Novel, 1981[2]"
+    ],
+    "created_at": "2023-11-13T23:48:48.876Z",
+    "villains": [
+      {
+        "name": "James Hollister",
+        "url": "https://stephen-king-api.onrender.com/api/villain/54"
+      },
+      {
+        "name": "Charlie McGee",
+        "url": "https://stephen-king-api.onrender.com/api/villain/73"
+      },
+      {
+        "name": "John Rainbird",
+        "url": "https://stephen-king-api.onrender.com/api/villain/86"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 9,
+    "Year": 1981,
+    "Title": "Roadwork",
+    "handle": "roadwork",
+    "Publisher": "Signet Books",
+    "ISBN": "978-0-451-09668-5",
+    "Pages": 274,
+    "Notes": [
+      "Published under pseudonym Richard Bachman"
+    ],
+    "created_at": "2023-11-13T23:48:49.005Z",
+    "villains": [],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 10,
+    "Year": 1981,
+    "Title": "Cujo",
+    "handle": "cujo",
+    "Publisher": "Viking Press",
+    "ISBN": "978-0-670-45193-7",
+    "Pages": 319,
+    "Notes": [
+      "Winner, British Fantasy Award’s August Derleth Award, 1982",
+      "Runner-up (21st place), Locus Award for Best Fantasy Novel, 1982[2]"
+    ],
+    "created_at": "2023-11-13T23:48:49.131Z",
+    "villains": [
+      {
+        "name": "Cujo",
+        "url": "https://stephen-king-api.onrender.com/api/villain/19"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 11,
+    "Year": 1982,
+    "Title": "The Running Man",
+    "handle": "the-running-man",
+    "Publisher": "Signet Books",
+    "ISBN": "978-0-451-11508-9",
+    "Pages": 219,
+    "Notes": [
+      "Published under pseudonym Richard Bachman"
+    ],
+    "created_at": "2023-11-13T23:48:49.252Z",
+    "villains": [
+      {
+        "name": "The Gladiators",
+        "url": "https://stephen-king-api.onrender.com/api/villain/42"
+      },
+      {
+        "name": "Damon Killian",
+        "url": "https://stephen-king-api.onrender.com/api/villain/63"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 12,
+    "Year": 1982,
+    "Title": "The Dark Tower: The Gunslinger",
+    "handle": "the-dark-tower-the-gunslinger",
+    "Publisher": "Grant",
+    "ISBN": "978-0-937986-50-9",
+    "Pages": 224,
+    "Notes": [
+      ""
+    ],
+    "created_at": "2023-11-13T23:48:49.374Z",
+    "villains": [
+      {
+        "name": "Marten Broadcloak",
+        "url": "https://stephen-king-api.onrender.com/api/villain/10"
+      },
+      {
+        "name": "Crimson King",
+        "url": "https://stephen-king-api.onrender.com/api/villain/17"
+      },
+      {
+        "name": "Randall Flagg",
+        "url": "https://stephen-king-api.onrender.com/api/villain/37"
+      },
+      {
+        "name": "Sylvia Pittston",
+        "url": "https://stephen-king-api.onrender.com/api/villain/84"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 13,
+    "Year": 1983,
+    "Title": "Christine",
+    "handle": "christine",
+    "Publisher": "Viking",
+    "ISBN": "978-0-670-22026-7",
+    "Pages": 526,
+    "Notes": [
+      "Runner-up (6th place), Locus Award for Best Fantasy Novel, 1984[2]"
+    ],
+    "created_at": "2023-11-13T23:48:49.505Z",
+    "villains": [
+      {
+        "name": "Christine (car)",
+        "url": "https://stephen-king-api.onrender.com/api/villain/11"
+      },
+      {
+        "name": "Arnie Cunningham",
+        "url": "https://stephen-king-api.onrender.com/api/villain/20"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 14,
+    "Year": 1983,
+    "Title": "Pet Sematary",
+    "handle": "pet-sematary",
+    "Publisher": "Doubleday",
+    "ISBN": "978-0-385-18244-7",
+    "Pages": 374,
+    "Notes": [
+      "Nominee, World Fantasy Award, 1984",
+      "Runner-up (7th place), Locus Award for Best Fantasy Novel, 1984[2]"
+    ],
+    "created_at": "2023-11-13T23:48:49.637Z",
+    "villains": [
+      {
+        "name": "Winston Church",
+        "url": "https://stephen-king-api.onrender.com/api/villain/13"
+      },
+      {
+        "name": "Gage Creed",
+        "url": "https://stephen-king-api.onrender.com/api/villain/15"
+      },
+      {
+        "name": "Victor Pascow",
+        "url": "https://stephen-king-api.onrender.com/api/villain/83"
+      },
+      {
+        "name": "Wendigo",
+        "url": "https://stephen-king-api.onrender.com/api/villain/110"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 15,
+    "Year": 1983,
+    "Title": "Cycle of the Werewolf",
+    "handle": "cycle-of-the-werewolf",
+    "Publisher": "Land of Enchantment",
+    "ISBN": "978-0-960-38282-8",
+    "Pages": 127,
+    "Notes": [
+      "Illustrated by Bernie Wrightson"
+    ],
+    "created_at": "2023-11-13T23:48:49.757Z",
+    "villains": [
+      {
+        "name": "Lester Lowe",
+        "url": "https://stephen-king-api.onrender.com/api/villain/68"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 16,
+    "Year": 1984,
+    "Title": "The Talisman",
+    "handle": "the-talisman",
+    "Publisher": "Viking",
+    "ISBN": "978-0-670-69199-9",
+    "Pages": 646,
+    "Notes": [
+      "Written with Peter Straub",
+      "Nominee, World Fantasy Award, 1985",
+      "Runner-up (4th place), Locus Award for Best Fantasy Novel, 1985[2]"
+    ],
+    "created_at": "2023-11-13T23:48:49.872Z",
+    "villains": [],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 17,
+    "Year": 1984,
+    "Title": "The Eyes of the Dragon",
+    "handle": "the-eyes-of-the-dragon",
+    "Publisher": "Philtrum Press (1984)Viking (1987)",
+    "ISBN": "978-0-670-81458-9",
+    "Pages": 326,
+    "Notes": [
+      "First published as a limited edition in 1984, then for the mass market in 1987"
+    ],
+    "created_at": "2023-11-13T23:48:49.988Z",
+    "villains": [
+      {
+        "name": "Randall Flagg",
+        "url": "https://stephen-king-api.onrender.com/api/villain/37"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 18,
+    "Year": 1984,
+    "Title": "Thinner",
+    "handle": "thinner",
+    "Publisher": "NAL",
+    "ISBN": "978-0-453-00468-8",
+    "Pages": 309,
+    "Notes": [
+      "Published under pseudonym Richard Bachman"
+    ],
+    "created_at": "2023-11-13T23:48:50.102Z",
+    "villains": [],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 19,
+    "Year": 1986,
+    "Title": "It",
+    "handle": "it",
+    "Publisher": "Viking",
+    "ISBN": "978-0-670-81302-5",
+    "Pages": 1138,
+    "Notes": [
+      "Winner, British Fantasy Award’s August Derleth Award, 1987",
+      "Nominee, World Fantasy Award, 1987",
+      "Runner-up (3rd place), Locus Award for Best Fantasy Novel, 1987[2]"
+    ],
+    "created_at": "2023-11-13T23:48:50.223Z",
+    "villains": [
+      {
+        "name": "Henry Bowers",
+        "url": "https://stephen-king-api.onrender.com/api/villain/7"
+      },
+      {
+        "name": "Butch Bowers",
+        "url": "https://stephen-king-api.onrender.com/api/villain/8"
+      },
+      {
+        "name": "Greta Bowie",
+        "url": "https://stephen-king-api.onrender.com/api/villain/9"
+      },
+      {
+        "name": "Victor Criss",
+        "url": "https://stephen-king-api.onrender.com/api/villain/18"
+      },
+      {
+        "name": "Marcia Fadden",
+        "url": "https://stephen-king-api.onrender.com/api/villain/35"
+      },
+      {
+        "name": "John Garton",
+        "url": "https://stephen-king-api.onrender.com/api/villain/39"
+      },
+      {
+        "name": "Peter Gordon",
+        "url": "https://stephen-king-api.onrender.com/api/villain/43"
+      },
+      {
+        "name": "Patrick Hockstetter",
+        "url": "https://stephen-king-api.onrender.com/api/villain/53"
+      },
+      {
+        "name": "Belch Huggins",
+        "url": "https://stephen-king-api.onrender.com/api/villain/55"
+      },
+      {
+        "name": "It (Creature)",
+        "url": "https://stephen-king-api.onrender.com/api/villain/57"
+      },
+      {
+        "name": "Richard P. Macklin",
+        "url": "https://stephen-king-api.onrender.com/api/villain/69"
+      },
+      {
+        "name": "Alvin Marsh",
+        "url": "https://stephen-king-api.onrender.com/api/villain/72"
+      },
+      {
+        "name": "Sally Mueller",
+        "url": "https://stephen-king-api.onrender.com/api/villain/79"
+      },
+      {
+        "name": "Tom Rogan",
+        "url": "https://stephen-king-api.onrender.com/api/villain/91"
+      },
+      {
+        "name": "Christopher Unwin",
+        "url": "https://stephen-king-api.onrender.com/api/villain/107"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 20,
+    "Year": 1987,
+    "Title": "The Dark Tower II: The Drawing of the Three",
+    "handle": "the-dark-tower-ii-the-drawing-of-the-three",
+    "Publisher": "Grant",
+    "ISBN": "978-0-937986-90-5",
+    "Pages": 400,
+    "Notes": [
+      "Runner-up (16th place), Locus Award for Best Fantasy Novel, 1988[2]"
+    ],
+    "created_at": "2023-11-13T23:48:50.339Z",
+    "villains": [
+      {
+        "name": "Jack Mort",
+        "url": "https://stephen-king-api.onrender.com/api/villain/76"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 21,
+    "Year": 1987,
+    "Title": "Misery",
+    "handle": "misery",
+    "Publisher": "Viking",
+    "ISBN": "978-0-670-81364-3",
+    "Pages": 310,
+    "Notes": [
+      "Winner, Bram Stoker Award, 1988",
+      "Nominee, World Fantasy Award, 1988[2]"
+    ],
+    "created_at": "2023-11-13T23:48:50.459Z",
+    "villains": [
+      {
+        "name": "Annie Wilkes",
+        "url": "https://stephen-king-api.onrender.com/api/villain/114"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 22,
+    "Year": 1987,
+    "Title": "The Tommyknockers",
+    "handle": "the-tommyknockers",
+    "Publisher": "Putnam",
+    "ISBN": "978-0-399-13314-5",
+    "Pages": 558,
+    "Notes": [
+      "Runner-up (16th place), Locus Award for Best Science Fiction Novel, 1988[2]"
+    ],
+    "created_at": "2023-11-13T23:48:50.579Z",
+    "villains": [
+      {
+        "name": "Tommyknockers",
+        "url": "https://stephen-king-api.onrender.com/api/villain/104"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 23,
+    "Year": 1989,
+    "Title": "The Dark Half",
+    "handle": "the-dark-half",
+    "Publisher": "Viking",
+    "ISBN": "978-0-670-82982-8",
+    "Pages": 431,
+    "Notes": [
+      "Runner-up (2nd place), Locus Award for Best Horror Novel, 1990[2]"
+    ],
+    "created_at": "2023-11-13T23:48:50.696Z",
+    "villains": [
+      {
+        "name": "George Stark",
+        "url": "https://stephen-king-api.onrender.com/api/villain/96"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 24,
+    "Year": 1990,
+    "Title": "The Stand Uncut",
+    "handle": "the-stand-uncut",
+    "Publisher": "Doubleday",
+    "ISBN": "978-0-385-19957-5",
+    "Pages": 1152,
+    "Notes": [
+      "The Complete & Uncut Edition",
+      "Runner-up (2nd place), Locus Award's Best Horror/Dark Fantasy Novel, 1991[2]"
+    ],
+    "created_at": "2023-11-13T23:48:50.809Z",
+    "villains": [],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 25,
+    "Year": 1991,
+    "Title": "The Dark Tower III: The Waste Lands",
+    "handle": "the-dark-tower-iii-the-waste-lands",
+    "Publisher": "Grant",
+    "ISBN": "978-0-937986-17-2",
+    "Pages": 512,
+    "Notes": [
+      "Nominee, Bram Stoker Award, 1992",
+      "Runner-up (3rd place), Locus Award for Best Horror/Dark Fantasy Novel, 1992[2]"
+    ],
+    "created_at": "2023-11-13T23:48:50.926Z",
+    "villains": [
+      {
+        "name": "Blaine the Mono",
+        "url": "https://stephen-king-api.onrender.com/api/villain/3"
+      },
+      {
+        "name": "Randall Flagg",
+        "url": "https://stephen-king-api.onrender.com/api/villain/37"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 26,
+    "Year": 1991,
+    "Title": "Needful Things",
+    "handle": "needful-things",
+    "Publisher": "Viking",
+    "ISBN": "978-0-670-83953-7",
+    "Pages": 690,
+    "Notes": [
+      "Nominee, Bram Stoker Award, 1992",
+      "Runner-up (13th place), Locus Award for Best Horror/Dark Fantasy Novel, 1992[2]"
+    ],
+    "created_at": "2023-11-13T23:48:51.044Z",
+    "villains": [
+      {
+        "name": "Leland Gaunt",
+        "url": "https://stephen-king-api.onrender.com/api/villain/40"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 27,
+    "Year": 1992,
+    "Title": "Gerald's Game",
+    "handle": "gerald-s-game",
+    "Publisher": "Viking",
+    "ISBN": "978-0-670-84650-4",
+    "Pages": 352,
+    "Notes": [],
+    "created_at": "2023-11-13T23:48:51.165Z",
+    "villains": [
+      {
+        "name": "Gerald Burlingame",
+        "url": "https://stephen-king-api.onrender.com/api/villain/41"
+      },
+      {
+        "name": "Raymond Andrew Joubert",
+        "url": "https://stephen-king-api.onrender.com/api/villain/61"
+      },
+      {
+        "name": "Tom Mahout",
+        "url": "https://stephen-king-api.onrender.com/api/villain/103"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 28,
+    "Year": 1992,
+    "Title": "Dolores Claiborne",
+    "handle": "dolores-claiborne",
+    "Publisher": "Viking",
+    "ISBN": "978-0-670-84452-4",
+    "Pages": 305,
+    "Notes": [
+      "Runner-up (14th place), Locus Award for Best Horror/Dark Fantasy Novel, 1993[2]"
+    ],
+    "created_at": "2023-11-13T23:48:51.295Z",
+    "villains": [
+      {
+        "name": "Joe St. George",
+        "url": "https://stephen-king-api.onrender.com/api/villain/95"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 29,
+    "Year": 1994,
+    "Title": "Insomnia",
+    "handle": "insomnia",
+    "Publisher": "Viking",
+    "ISBN": "978-0-670-85503-2",
+    "Pages": 787,
+    "Notes": [
+      "Nominee, Bram Stoker Award, 1995",
+      "Runner-up (3rd place), Locus Award for Best Fantasy/Horror Novel, 1995[2]"
+    ],
+    "created_at": "2023-11-13T23:48:51.415Z",
+    "villains": [
+      {
+        "name": "Crimson King",
+        "url": "https://stephen-king-api.onrender.com/api/villain/17"
+      },
+      {
+        "name": "Susan Day",
+        "url": "https://stephen-king-api.onrender.com/api/villain/23"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 30,
+    "Year": 1995,
+    "Title": "Rose Madder",
+    "handle": "rose-madder",
+    "Publisher": "Viking",
+    "ISBN": "978-0-670-85869-9",
+    "Pages": 420,
+    "Notes": [
+      "Runner-up (3rd place), Locus Award for Best Horror/Dark Fantasy Novel, 1995[2]"
+    ],
+    "created_at": "2023-11-13T23:48:51.533Z",
+    "villains": [
+      {
+        "name": "Norman Daniels",
+        "url": "https://stephen-king-api.onrender.com/api/villain/22"
+      },
+      {
+        "name": "Susan Day",
+        "url": "https://stephen-king-api.onrender.com/api/villain/23"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 31,
+    "Year": 1996,
+    "Title": "The Green Mile",
+    "handle": "the-green-mile",
+    "Publisher": "Signet Books",
+    "ISBN": "978-0-451-19049-9978-0-451-19052-9978-0-451-19054-3978-0-451-19055-0978-0-451-19056-7978-0-451-19057-4",
+    "Pages": 400,
+    "Notes": [
+      "Winner, Bram Stoker Award, 1997",
+      "Runner-up (8th place), Locus Award for Best Horror/Dark Fantasy Novel, 1997[2]"
+    ],
+    "created_at": "2023-11-13T23:48:51.660Z",
+    "villains": [
+      {
+        "name": "Percy Wetmore",
+        "url": "https://stephen-king-api.onrender.com/api/villain/111"
+      },
+      {
+        "name": "William Wharton",
+        "url": "https://stephen-king-api.onrender.com/api/villain/112"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 32,
+    "Year": 1996,
+    "Title": "Desperation",
+    "handle": "desperation",
+    "Publisher": "Viking",
+    "ISBN": "978-0-670-86836-0",
+    "Pages": 704,
+    "Notes": [
+      "Twin novel of The Regulators",
+      "Winner, Locus Award for Best Horror/Dark Fantasy Novel, 1997[2]"
+    ],
+    "created_at": "2023-11-13T23:48:51.784Z",
+    "villains": [],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 33,
+    "Year": 1996,
+    "Title": "The Regulators",
+    "handle": "the-regulators",
+    "Publisher": "Dutton",
+    "ISBN": "978-0-525-94190-3",
+    "Pages": 480,
+    "Notes": [
+      "Published under pseudonym Richard Bachman",
+      "Twin novel of Desperation"
+    ],
+    "created_at": "2023-11-13T23:48:51.900Z",
+    "villains": [],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 34,
+    "Year": 1997,
+    "Title": "The Dark Tower IV: Wizard and Glass",
+    "handle": "the-dark-tower-iv-wizard-and-glass",
+    "Publisher": "Grant",
+    "ISBN": "978-1-880418-38-3",
+    "Pages": 787,
+    "Notes": [
+      "Runner-up (4th place), Locus Award for Best Fantasy Novel, 1998",
+      "Runner-up (6th place), Locus Award for Best Art Book, 1998[2]"
+    ],
+    "created_at": "2023-11-13T23:48:52.019Z",
+    "villains": [
+      {
+        "name": "Blaine the Mono",
+        "url": "https://stephen-king-api.onrender.com/api/villain/3"
+      },
+      {
+        "name": "Cordelia Delgado",
+        "url": "https://stephen-king-api.onrender.com/api/villain/24"
+      },
+      {
+        "name": "Rhea Dubativo",
+        "url": "https://stephen-king-api.onrender.com/api/villain/32"
+      },
+      {
+        "name": "John Farson",
+        "url": "https://stephen-king-api.onrender.com/api/villain/36"
+      },
+      {
+        "name": "Randall Flagg",
+        "url": "https://stephen-king-api.onrender.com/api/villain/37"
+      },
+      {
+        "name": "Eldred Jonas",
+        "url": "https://stephen-king-api.onrender.com/api/villain/60"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 35,
+    "Year": 1998,
+    "Title": "Bag of Bones",
+    "handle": "bag-of-bones",
+    "Publisher": "Scribner",
+    "ISBN": "978-0-684-85350-5",
+    "Pages": 529,
+    "Notes": [
+      "Winner, Bram Stoker Award, 1999",
+      "Winner, British Fantasy Award’s August Derleth Award, 1999",
+      "Winner, Locus Award for Best Dark Fantasy/Horror Novel, 1999[2]"
+    ],
+    "created_at": "2023-11-13T23:48:52.137Z",
+    "villains": [],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 36,
+    "Year": 1999,
+    "Title": "The Girl Who Loved Tom Gordon",
+    "handle": "the-girl-who-loved-tom-gordon",
+    "Publisher": "Scribner",
+    "ISBN": "978-0-684-86762-5",
+    "Pages": 224,
+    "Notes": [],
+    "created_at": "2023-11-13T23:48:52.251Z",
+    "villains": [],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 37,
+    "Year": 2001,
+    "Title": "Dreamcatcher",
+    "handle": "dreamcatcher",
+    "Publisher": "Scribner",
+    "ISBN": "978-0-743-21138-3",
+    "Pages": 620,
+    "Notes": [],
+    "created_at": "2023-11-13T23:48:52.368Z",
+    "villains": [],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 38,
+    "Year": 2001,
+    "Title": "Black House",
+    "handle": "black-house",
+    "Publisher": "Random House",
+    "ISBN": "978-0-375-50439-6",
+    "Pages": 625,
+    "Notes": [
+      "Sequel to The Talisman",
+      "Written with Peter Straub",
+      "Nominee, Bram Stoker Award, 2002",
+      "Runner-up (7th place), Locus Award for Best Fantasy Novel, 2002[2]"
+    ],
+    "created_at": "2023-11-13T23:48:52.483Z",
+    "villains": [
+      {
+        "name": "Crimson King",
+        "url": "https://stephen-king-api.onrender.com/api/villain/17"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 39,
+    "Year": 2002,
+    "Title": "From a Buick 8",
+    "handle": "from-a-buick-8",
+    "Publisher": "Scribner",
+    "ISBN": "978-0-743-21137-6",
+    "Pages": 368,
+    "Notes": [
+      "Nominee, Bram Stoker Award, 2003"
+    ],
+    "created_at": "2023-11-13T23:48:52.604Z",
+    "villains": [
+      {
+        "name": "Brian Lippy",
+        "url": "https://stephen-king-api.onrender.com/api/villain/66"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 40,
+    "Year": 2003,
+    "Title": "The Dark Tower V: Wolves of the Calla",
+    "handle": "the-dark-tower-v-wolves-of-the-calla",
+    "Publisher": "Grant",
+    "ISBN": "978-1-880-41856-7",
+    "Pages": 714,
+    "Notes": [
+      "Nominee, Bram Stoker Award, 2004",
+      "Runner-up (4th place), Locus Award for Best Fantasy Novel, 2004[2]"
+    ],
+    "created_at": "2023-11-13T23:48:52.735Z",
+    "villains": [],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 41,
+    "Year": 2004,
+    "Title": "The Dark Tower VI: Song of Susannah",
+    "handle": "the-dark-tower-vi-song-of-susannah",
+    "Publisher": "Grant",
+    "ISBN": "978-1-880-41859-8",
+    "Pages": 432,
+    "Notes": [
+      "Runner-up (4th place), Locus Award for Best Fantasy Novel, 2005"
+    ],
+    "created_at": "2023-11-13T23:48:52.856Z",
+    "villains": [],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 42,
+    "Year": 2004,
+    "Title": "The Dark Tower VII: The Dark Tower",
+    "handle": "the-dark-tower-vii-the-dark-tower",
+    "Publisher": "978-1-880-41862-8",
+    "ISBN": "Grant",
+    "Pages": 845,
+    "Notes": [
+      "Winner, British Fantasy Award's August Derleth Award, 2005",
+      "Nominee, Bram Stoker Award, 2005[2]"
+    ],
+    "created_at": "2023-11-13T23:48:53.001Z",
+    "villains": [
+      {
+        "name": "Crimson King",
+        "url": "https://stephen-king-api.onrender.com/api/villain/17"
+      },
+      {
+        "name": "Dandelo",
+        "url": "https://stephen-king-api.onrender.com/api/villain/21"
+      },
+      {
+        "name": "Mordred Deschain",
+        "url": "https://stephen-king-api.onrender.com/api/villain/27"
+      },
+      {
+        "name": "Randall Flagg",
+        "url": "https://stephen-king-api.onrender.com/api/villain/37"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 43,
+    "Year": 2005,
+    "Title": "The Colorado Kid",
+    "handle": "the-colorado-kid",
+    "Publisher": "Hard Case Crime",
+    "ISBN": "978-0-843-95584-2",
+    "Pages": 184,
+    "Notes": [],
+    "created_at": "2023-11-13T23:48:53.124Z",
+    "villains": [],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 44,
+    "Year": 2006,
+    "Title": "Cell",
+    "handle": "cell",
+    "Publisher": "Scribner",
+    "ISBN": "978-0-743-29233-7",
+    "Pages": 351,
+    "Notes": [],
+    "created_at": "2023-11-13T23:48:53.244Z",
+    "villains": [
+      {
+        "name": "The Raggedy Man",
+        "url": "https://stephen-king-api.onrender.com/api/villain/85"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 45,
+    "Year": 2006,
+    "Title": "Lisey's Story",
+    "handle": "lisey-s-story",
+    "Publisher": "Scribner",
+    "ISBN": "978-0-743-28941-2",
+    "Pages": 528,
+    "Notes": [
+      "Winner, Bram Stoker Award, 2007",
+      "Nominee, World Fantasy Award, 2007",
+      "Runner-up (10th place), Locus Award for Best Fantasy Novel, 2007[2]"
+    ],
+    "created_at": "2023-11-13T23:48:53.382Z",
+    "villains": [],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 46,
+    "Year": 2007,
+    "Title": "Blaze",
+    "handle": "blaze",
+    "Publisher": "Scribner",
+    "ISBN": "978-1-416-55484-4",
+    "Pages": 304,
+    "Notes": [
+      "Published under pseudonym Richard Bachman"
+    ],
+    "created_at": "2023-11-13T23:48:53.504Z",
+    "villains": [],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 47,
+    "Year": 2008,
+    "Title": "Duma Key",
+    "handle": "duma-key",
+    "Publisher": "Scribner",
+    "ISBN": "978-1-416-55251-2",
+    "Pages": 607,
+    "Notes": [
+      "Winner, Bram Stoker Award,  2009[2]"
+    ],
+    "created_at": "2023-11-13T23:48:53.622Z",
+    "villains": [],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 48,
+    "Year": 2009,
+    "Title": "Under the Dome",
+    "handle": "under-the-dome",
+    "Publisher": "Scribner",
+    "ISBN": "978-1-439-14850-1",
+    "Pages": 1074,
+    "Notes": [
+      "Nominee, British Fantasy Award's August Derleth Award, 2010",
+      "Runner-up (7th place), Locus Award for Best Science Fiction Novel, 2010[2]"
+    ],
+    "created_at": "2023-11-13T23:48:53.748Z",
+    "villains": [
+      {
+        "name": "Jim Rennie, Jr.",
+        "url": "https://stephen-king-api.onrender.com/api/villain/88"
+      },
+      {
+        "name": "Jim Rennie",
+        "url": "https://stephen-king-api.onrender.com/api/villain/89"
+      },
+      {
+        "name": "Carter Thibodeau",
+        "url": "https://stephen-king-api.onrender.com/api/villain/101"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 49,
+    "Year": 2011,
+    "Title": "11/22/63",
+    "handle": "11-22-63",
+    "Publisher": "Scribner",
+    "ISBN": "978-1-451-62728-2",
+    "Pages": 849,
+    "Notes": [
+      "Nominee, British Fantasy Award, 2012",
+      "Nominee, World Fantasy Award, 2012",
+      "Runner-up (2nd place), Locus Award for Best Science Fiction Novel, 2012[2]"
+    ],
+    "created_at": "2023-11-13T23:48:53.869Z",
+    "villains": [],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 50,
+    "Year": 2012,
+    "Title": "The Dark Tower: The Wind Through the Keyhole",
+    "handle": "the-dark-tower-the-wind-through-the-keyhole",
+    "Publisher": "Grant",
+    "ISBN": "978-1-880-41876-5",
+    "Pages": 336,
+    "Notes": [
+      "The eighth Dark Tower novel, but chronologically set between the fourth and fifth volumes."
+    ],
+    "created_at": "2023-11-13T23:48:53.984Z",
+    "villains": [],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 51,
+    "Year": 2013,
+    "Title": "Joyland",
+    "handle": "joyland",
+    "Publisher": "Hard Case Crime",
+    "ISBN": "978-1-781-16264-4",
+    "Pages": 288,
+    "Notes": [
+      "Nominee, Edgar Award for Best Paperback Original, 2014[3]",
+      "Runner-up (11th place), Locus Award for Best Fantasy Novel, 2014[2]"
+    ],
+    "created_at": "2023-11-13T23:48:54.117Z",
+    "villains": [
+      {
+        "name": "Lane Hardy",
+        "url": "https://stephen-king-api.onrender.com/api/villain/48"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 52,
+    "Year": 2013,
+    "Title": "Doctor Sleep",
+    "handle": "doctor-sleep",
+    "Publisher": "Scribner",
+    "ISBN": "978-1-476-72765-3",
+    "Pages": 531,
+    "Notes": [
+      "Sequel to The Shining",
+      "Winner, Bram Stoker Award, 2014",
+      "Runner-up (5th place), Locus Award for Best Fantasy Novel, 2014[2]"
+    ],
+    "created_at": "2023-11-13T23:48:54.259Z",
+    "villains": [
+      {
+        "name": "Rose the Hat",
+        "url": "https://stephen-king-api.onrender.com/api/villain/31"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 53,
+    "Year": 2014,
+    "Title": "Mr. Mercedes",
+    "handle": "mr-mercedes",
+    "Publisher": "Scribner",
+    "ISBN": "978-1-476-75445-1",
+    "Pages": 436,
+    "Notes": [
+      "First novel in the Bill Hodges Trilogy",
+      "Winner, Edgar Award for Best Novel, 2015[3]"
+    ],
+    "created_at": "2023-11-13T23:48:54.379Z",
+    "villains": [
+      {
+        "name": "Brady Hartsfield",
+        "url": "https://stephen-king-api.onrender.com/api/villain/50"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 54,
+    "Year": 2014,
+    "Title": "Revival",
+    "handle": "revival",
+    "Publisher": "Scribner",
+    "ISBN": "978-1-476-77038-3",
+    "Pages": 403,
+    "Notes": [
+      "Runner-up (8th place), Locus Award for Best Fantasy Novel, 2015[2]"
+    ],
+    "created_at": "2023-11-13T23:48:54.494Z",
+    "villains": [
+      {
+        "name": "Mother of the Null",
+        "url": "https://stephen-king-api.onrender.com/api/villain/78"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 55,
+    "Year": 2015,
+    "Title": "Finders Keepers",
+    "handle": "finders-keepers",
+    "Publisher": "Scribner",
+    "ISBN": "978-1-501-10007-9",
+    "Pages": 434,
+    "Notes": [
+      "Second novel in the Bill Hodges Trilogy."
+    ],
+    "created_at": "2023-11-13T23:48:54.614Z",
+    "villains": [
+      {
+        "name": "Brady Hartsfield",
+        "url": "https://stephen-king-api.onrender.com/api/villain/50"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 56,
+    "Year": 2016,
+    "Title": "End of Watch",
+    "handle": "end-of-watch",
+    "Publisher": "Scribner",
+    "ISBN": "978-1-501-12974-2",
+    "Pages": 496,
+    "Notes": [
+      "Third novel in the Bill Hodges Trilogy."
+    ],
+    "created_at": "2023-11-13T23:48:54.730Z",
+    "villains": [
+      {
+        "name": "Brady Hartsfield",
+        "url": "https://stephen-king-api.onrender.com/api/villain/50"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 57,
+    "Year": 2017,
+    "Title": "Gwendy's Button Box",
+    "handle": "gwendy-s-button-box",
+    "Publisher": "Cemetery Dance Publications",
+    "ISBN": "978-1-58767-610-9",
+    "Pages": 175,
+    "Notes": [
+      "Written with Richard Chizmar"
+    ],
+    "created_at": "2023-11-13T23:48:54.850Z",
+    "villains": [],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 58,
+    "Year": 2017,
+    "Title": "Sleeping Beauties",
+    "handle": "sleeping-beauties",
+    "Publisher": "Scribner",
+    "ISBN": "978-1-50116-340-1",
+    "Pages": 702,
+    "Notes": [
+      "Written with Owen King",
+      "Nominee, Bram Stoker Award, 2018[2]"
+    ],
+    "created_at": "2023-11-13T23:48:54.973Z",
+    "villains": [],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 59,
+    "Year": 2018,
+    "Title": "The Outsider",
+    "handle": "the-outsider",
+    "Publisher": "Scribner",
+    "ISBN": "978-1-50118-098-9",
+    "Pages": 576,
+    "Notes": [
+      "First novel in the Holly Gibney Series",
+      "Runner-up (2nd place), Locus Award for Best Horror Novel, 2019[2]"
+    ],
+    "created_at": "2023-11-13T23:48:55.165Z",
+    "villains": [
+      {
+        "name": "The Outsider (Creature)",
+        "url": "https://stephen-king-api.onrender.com/api/villain/82"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 60,
+    "Year": 2018,
+    "Title": "Elevation",
+    "handle": "elevation",
+    "Publisher": "Scribner",
+    "ISBN": "978-1-98210-231-9",
+    "Pages": 144,
+    "Notes": [],
+    "created_at": "2023-11-13T23:48:55.291Z",
+    "villains": [],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 61,
+    "Year": 2019,
+    "Title": "The Institute",
+    "handle": "the-institute",
+    "Publisher": "Scribner",
+    "ISBN": "978-1-98211-056-7",
+    "Pages": 576,
+    "Notes": [
+      "Nominee, British Fantasy Award's August Derleth Award, 2020",
+      "Runner-up (3rd place), Locus Award for Best Horror Novel, 2020[2]"
+    ],
+    "created_at": "2023-11-13T23:48:55.457Z",
+    "villains": [
+      {
+        "name": "Gladys Hickson",
+        "url": "https://stephen-king-api.onrender.com/api/villain/52"
+      }
+    ],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 62,
+    "Year": 2021,
+    "Title": "Later",
+    "handle": "later",
+    "Publisher": "Hard Case Crime",
+    "ISBN": "978-1-78909-649-1",
+    "Pages": 256,
+    "Notes": [],
+    "created_at": "2023-11-13T23:48:55.579Z",
+    "villains": [],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  },
+  {
+    "id": 63,
+    "Year": 2021,
+    "Title": "Billy Summers",
+    "handle": "billy-summers",
+    "Publisher": "Scribner",
+    "ISBN": "978-1-982-17361-6",
+    "Pages": 528,
+    "Notes": [],
+    "created_at": "2023-11-13T23:48:55.753Z",
+    "villains": [],
+    "googleBooksDataAvailable": false,
+    "coverImageUrl": "NO_COVER_AVAILABLE",
+    "largeCoverImageUrl": "NO_COVER_AVAILABLE"
+  }
+]

--- a/src/app/data/shorts.json
+++ b/src/app/data/shorts.json
@@ -1,0 +1,2852 @@
+[
+  {
+    "id": 1,
+    "title": "Land of 1,000,000 Years Ago",
+    "type": "short story",
+    "handle": "land-of-1-000-000-years-ago",
+    "originallyPublishedIn": "",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Self-published"
+    ],
+    "year": 1959,
+    "created_at": "2023-11-13T23:48:55.954Z",
+    "villains": []
+  },
+  {
+    "id": 2,
+    "title": "Thirty-One of the Classics",
+    "type": "novella",
+    "handle": "thirty-one-of-the-classics",
+    "originallyPublishedIn": "",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Self-published"
+    ],
+    "year": 1959,
+    "created_at": "2023-11-13T23:48:56.271Z",
+    "villains": []
+  },
+  {
+    "id": 3,
+    "title": "Jumper",
+    "type": "short story",
+    "handle": "jumper",
+    "originallyPublishedIn": "Dave's Rag (1959)",
+    "collectedIn": "Secret Windows (2000)",
+    "notes": [
+      "Self-published"
+    ],
+    "year": 1959,
+    "created_at": "2023-11-13T23:48:56.385Z",
+    "villains": []
+  },
+  {
+    "id": 4,
+    "title": "Rush Call",
+    "type": "short story",
+    "handle": "rush-call",
+    "originallyPublishedIn": "Dave's Rag (1960)",
+    "collectedIn": "Secret Windows (2000)",
+    "notes": [
+      "Self-published"
+    ],
+    "year": 1960,
+    "created_at": "2023-11-13T23:48:56.521Z",
+    "villains": []
+  },
+  {
+    "id": 5,
+    "title": "The Cursed Expedition",
+    "type": "short story",
+    "handle": "the-cursed-expedition",
+    "originallyPublishedIn": "People, Places and Things (1960)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Self-published"
+    ],
+    "year": 1960,
+    "created_at": "2023-11-13T23:48:56.637Z",
+    "villains": []
+  },
+  {
+    "id": 6,
+    "title": "I've Got to Get Away!",
+    "type": "short story",
+    "handle": "i-ve-got-to-get-away-",
+    "originallyPublishedIn": "People, Places and Things (1960)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Self-published"
+    ],
+    "year": 1960,
+    "created_at": "2023-11-13T23:48:56.761Z",
+    "villains": []
+  },
+  {
+    "id": 7,
+    "title": "Hotel at the End of the Road",
+    "type": "short story",
+    "handle": "hotel-at-the-end-of-the-road",
+    "originallyPublishedIn": "People, Places and Things (1960)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Self-published"
+    ],
+    "year": 1960,
+    "created_at": "2023-11-13T23:48:56.880Z",
+    "villains": []
+  },
+  {
+    "id": 8,
+    "title": "Never Look Behind You",
+    "type": "short story",
+    "handle": "never-look-behind-you",
+    "originallyPublishedIn": "People, Places and Things (1960)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Self-published"
+    ],
+    "year": 1960,
+    "created_at": "2023-11-13T23:48:57.004Z",
+    "villains": []
+  },
+  {
+    "id": 9,
+    "title": "The Other Side of the Fog",
+    "type": "short story",
+    "handle": "the-other-side-of-the-fog",
+    "originallyPublishedIn": "People, Places and Things (1960)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Self-published"
+    ],
+    "year": 1960,
+    "created_at": "2023-11-13T23:48:57.127Z",
+    "villains": []
+  },
+  {
+    "id": 10,
+    "title": "The Stranger",
+    "type": "short story",
+    "handle": "the-stranger",
+    "originallyPublishedIn": "People, Places and Things (1960)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Self-published"
+    ],
+    "year": 1960,
+    "created_at": "2023-11-13T23:48:57.249Z",
+    "villains": []
+  },
+  {
+    "id": 11,
+    "title": "The Thing at the Bottom of the Well",
+    "type": "short story",
+    "handle": "the-thing-at-the-bottom-of-the-well",
+    "originallyPublishedIn": "People, Places and Things (1960)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Self-published"
+    ],
+    "year": 1960,
+    "created_at": "2023-11-13T23:48:57.371Z",
+    "villains": []
+  },
+  {
+    "id": 12,
+    "title": "The Pit and the Pendulum",
+    "type": "short story",
+    "handle": "the-pit-and-the-pendulum",
+    "originallyPublishedIn": "The Pit and the Pendulum (1961)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Self-published"
+    ],
+    "year": 1961,
+    "created_at": "2023-11-13T23:48:57.497Z",
+    "villains": []
+  },
+  {
+    "id": 13,
+    "title": "The Undead",
+    "type": "short story",
+    "handle": "the-undead",
+    "originallyPublishedIn": "The Undead (1963)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Self-published"
+    ],
+    "year": 1963,
+    "created_at": "2023-11-13T23:48:57.617Z",
+    "villains": []
+  },
+  {
+    "id": 14,
+    "title": "Trigger Finger",
+    "type": "short story",
+    "handle": "trigger-finger",
+    "originallyPublishedIn": "Trigger Finger (1963)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Self-published"
+    ],
+    "year": 1963,
+    "created_at": "2023-11-13T23:48:57.736Z",
+    "villains": []
+  },
+  {
+    "id": 15,
+    "title": "The Star Invaders",
+    "type": "short story",
+    "handle": "the-star-invaders",
+    "originallyPublishedIn": "The Star Invaders (1964)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Self-published"
+    ],
+    "year": 1964,
+    "created_at": "2023-11-13T23:48:57.861Z",
+    "villains": []
+  },
+  {
+    "id": 16,
+    "title": "Codename: Mousetrap",
+    "type": "short story",
+    "handle": "codename-mousetrap",
+    "originallyPublishedIn": "The Drum (October 27, 1965)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Lisbon Falls High School publication"
+    ],
+    "year": 1965,
+    "created_at": "2023-11-13T23:48:57.981Z",
+    "villains": []
+  },
+  {
+    "id": 17,
+    "title": "I Was a Teenage Grave Robber",
+    "type": "short story",
+    "handle": "i-was-a-teenage-grave-robber",
+    "originallyPublishedIn": "Comics Review (1965)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "First published in Comics Review, 1965. Later reprinted in Stories of Suspense (1965) retitled as “In a Half-World of Terror”. Partly reprinted in The Stephen King Illustrated Companion (edited by Bev Vincent, 2009)."
+    ],
+    "year": 1965,
+    "created_at": "2023-11-13T23:48:58.106Z",
+    "villains": []
+  },
+  {
+    "id": 18,
+    "title": "The 43rd Dream",
+    "type": "short story",
+    "handle": "the-43rd-dream",
+    "originallyPublishedIn": "The Drum (January 29, 1966)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Lisbon Falls High School publication"
+    ],
+    "year": 1966,
+    "created_at": "2023-11-13T23:48:58.231Z",
+    "villains": []
+  },
+  {
+    "id": 19,
+    "title": "The Glass Floor",
+    "type": "short story",
+    "handle": "the-glass-floor",
+    "originallyPublishedIn": "Startling Mystery Stories (Fall 1967)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "First professional story"
+    ],
+    "year": 1967,
+    "created_at": "2023-11-13T23:48:58.360Z",
+    "villains": []
+  },
+  {
+    "id": 20,
+    "title": "Cain Rose Up",
+    "type": "short story",
+    "handle": "cain-rose-up",
+    "originallyPublishedIn": "Ubris (Spring 1968)",
+    "collectedIn": "Skeleton Crew (1985)",
+    "notes": [],
+    "year": 1968,
+    "created_at": "2023-11-13T23:48:58.480Z",
+    "villains": []
+  },
+  {
+    "id": 21,
+    "title": "Here There Be Tygers",
+    "type": "short story",
+    "handle": "here-there-be-tygers",
+    "originallyPublishedIn": "Ubris (Spring 1968)",
+    "collectedIn": "Skeleton Crew (1985)",
+    "notes": [],
+    "year": 1968,
+    "created_at": "2023-11-13T23:48:58.612Z",
+    "villains": []
+  },
+  {
+    "id": 22,
+    "title": "Harrison State Park '68",
+    "type": "poem",
+    "handle": "harrison-state-park-68",
+    "originallyPublishedIn": "Ubris (Fall 1968)",
+    "collectedIn": "Uncollected",
+    "notes": [],
+    "year": 1968,
+    "created_at": "2023-11-13T23:48:58.740Z",
+    "villains": []
+  },
+  {
+    "id": 23,
+    "title": "Strawberry Spring",
+    "type": "short story",
+    "handle": "strawberry-spring",
+    "originallyPublishedIn": "Ubris (Fall 1968)",
+    "collectedIn": "Night Shift (1978)",
+    "notes": [
+      "Collected heavily revised"
+    ],
+    "year": 1968,
+    "created_at": "2023-11-13T23:48:58.863Z",
+    "villains": []
+  },
+  {
+    "id": 24,
+    "title": "Night Surf",
+    "type": "short story",
+    "handle": "night-surf",
+    "originallyPublishedIn": "Ubris (Spring 1969)",
+    "collectedIn": "Night Shift (1978)",
+    "notes": [
+      "Collected heavily revised"
+    ],
+    "year": 1969,
+    "created_at": "2023-11-13T23:48:58.978Z",
+    "villains": []
+  },
+  {
+    "id": 25,
+    "title": "The Reaper's Image",
+    "type": "short story",
+    "handle": "the-reaper-s-image",
+    "originallyPublishedIn": "Startling Mystery Stories (Spring 1969)",
+    "collectedIn": "Skeleton Crew (1985)",
+    "notes": [
+      "Collected heavily revised"
+    ],
+    "year": 1969,
+    "created_at": "2023-11-13T23:48:59.097Z",
+    "villains": []
+  },
+  {
+    "id": 26,
+    "title": "The Dark Man",
+    "type": "poem",
+    "handle": "the-dark-man",
+    "originallyPublishedIn": "Ubris (Fall 1969)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Republished as a standalone book (2013)"
+    ],
+    "year": 1969,
+    "created_at": "2023-11-13T23:48:59.213Z",
+    "villains": []
+  },
+  {
+    "id": 27,
+    "title": "Stud City",
+    "type": "short story",
+    "handle": "stud-city",
+    "originallyPublishedIn": "Ubris (Fall 1969)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Incorporated into The Body (1982)"
+    ],
+    "year": 1969,
+    "created_at": "2023-11-13T23:48:59.343Z",
+    "villains": []
+  },
+  {
+    "id": 28,
+    "title": "Slade",
+    "type": "short story",
+    "handle": "slade",
+    "originallyPublishedIn": "The Maine Campus (June 11 – August 6, 1970)",
+    "collectedIn": "Uncollected",
+    "notes": [],
+    "year": 1970,
+    "created_at": "2023-11-13T23:48:59.464Z",
+    "villains": []
+  },
+  {
+    "id": 29,
+    "title": "Graveyard Shift",
+    "type": "short story",
+    "handle": "graveyard-shift",
+    "originallyPublishedIn": "Cavalier (October 1970)",
+    "collectedIn": "Night Shift (1978)",
+    "notes": [],
+    "year": 1970,
+    "created_at": "2023-11-13T23:48:59.601Z",
+    "villains": []
+  },
+  {
+    "id": 30,
+    "title": "Donovan's Brain",
+    "type": "poem",
+    "handle": "donovan-s-brain",
+    "originallyPublishedIn": "Moth  (1970)",
+    "collectedIn": "Uncollected",
+    "notes": [],
+    "year": 1970,
+    "created_at": "2023-11-13T23:48:59.726Z",
+    "villains": []
+  },
+  {
+    "id": 31,
+    "title": "Silence",
+    "type": "poem",
+    "handle": "silence",
+    "originallyPublishedIn": "Moth  (1970)",
+    "collectedIn": "Uncollected",
+    "notes": [],
+    "year": 1970,
+    "created_at": "2023-11-13T23:48:59.845Z",
+    "villains": []
+  },
+  {
+    "id": 32,
+    "title": "The Blue Air Compressor",
+    "type": "short story",
+    "handle": "the-blue-air-compressor",
+    "originallyPublishedIn": "Onan (January 1971)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Republished revised in Heavy Metal (July 1981)"
+    ],
+    "year": 1971,
+    "created_at": "2023-11-13T23:48:59.967Z",
+    "villains": []
+  },
+  {
+    "id": 33,
+    "title": "In the Key Chords of Dawn",
+    "type": "poem",
+    "handle": "in-the-key-chords-of-dawn",
+    "originallyPublishedIn": "Onan (January 1971)",
+    "collectedIn": "Uncollected",
+    "notes": [],
+    "year": 1971,
+    "created_at": "2023-11-13T23:49:00.091Z",
+    "villains": []
+  },
+  {
+    "id": 34,
+    "title": "I Am the Doorway",
+    "type": "short story",
+    "handle": "i-am-the-doorway",
+    "originallyPublishedIn": "Cavalier (March 1971)",
+    "collectedIn": "Night Shift (1978)",
+    "notes": [],
+    "year": 1971,
+    "created_at": "2023-11-13T23:49:00.211Z",
+    "villains": []
+  },
+  {
+    "id": 35,
+    "title": "Brooklyn August",
+    "type": "poem",
+    "handle": "brooklyn-august",
+    "originallyPublishedIn": "Io #10 (1971)",
+    "collectedIn": "Nightmares & Dreamscapes (1993)",
+    "notes": [],
+    "year": 1971,
+    "created_at": "2023-11-13T23:49:00.332Z",
+    "villains": []
+  },
+  {
+    "id": 36,
+    "title": "She Has Gone to Sleep While...",
+    "type": "poem",
+    "handle": "she-has-gone-to-sleep-while-",
+    "originallyPublishedIn": "Contraband #1 (1971)",
+    "collectedIn": "Uncollected",
+    "notes": [],
+    "year": 1971,
+    "created_at": "2023-11-13T23:49:00.453Z",
+    "villains": []
+  },
+  {
+    "id": 37,
+    "title": "Woman with Child",
+    "type": "poem",
+    "handle": "woman-with-child",
+    "originallyPublishedIn": "Contraband #1 (1971)",
+    "collectedIn": "Uncollected",
+    "notes": [],
+    "year": 1971,
+    "created_at": "2023-11-13T23:49:00.582Z",
+    "villains": []
+  },
+  {
+    "id": 38,
+    "title": "The Hardcase Speaks",
+    "type": "poem",
+    "handle": "the-hardcase-speaks",
+    "originallyPublishedIn": "Contraband #2 (1971)",
+    "collectedIn": "Uncollected",
+    "notes": [],
+    "year": 1971,
+    "created_at": "2023-11-13T23:49:00.702Z",
+    "villains": []
+  },
+  {
+    "id": 39,
+    "title": "Suffer the Little Children",
+    "type": "short story",
+    "handle": "suffer-the-little-children",
+    "originallyPublishedIn": "Cavalier (February 1972)",
+    "collectedIn": "Nightmares & Dreamscapes (1993)",
+    "notes": [],
+    "year": 1972,
+    "created_at": "2023-11-13T23:49:00.825Z",
+    "villains": []
+  },
+  {
+    "id": 40,
+    "title": "The Fifth Quarter",
+    "type": "short story",
+    "handle": "the-fifth-quarter",
+    "originallyPublishedIn": "Cavalier (April 1972)",
+    "collectedIn": "Nightmares & Dreamscapes (1993)",
+    "notes": [
+      "As John Swithen"
+    ],
+    "year": 1972,
+    "created_at": "2023-11-13T23:49:00.949Z",
+    "villains": []
+  },
+  {
+    "id": 41,
+    "title": "Battleground",
+    "type": "short story",
+    "handle": "battleground",
+    "originallyPublishedIn": "Cavalier (September 1972)",
+    "collectedIn": "Night Shift (1978)",
+    "notes": [],
+    "year": 1972,
+    "created_at": "2023-11-13T23:49:01.075Z",
+    "villains": []
+  },
+  {
+    "id": 42,
+    "title": "The Mangler",
+    "type": "short story",
+    "handle": "the-mangler",
+    "originallyPublishedIn": "Cavalier (December 1972)",
+    "collectedIn": "Night Shift (1978)",
+    "notes": [],
+    "year": 1972,
+    "created_at": "2023-11-13T23:49:01.192Z",
+    "villains": []
+  },
+  {
+    "id": 43,
+    "title": "The Boogeyman",
+    "type": "short story",
+    "handle": "the-boogeyman",
+    "originallyPublishedIn": "Cavalier (March 1973)",
+    "collectedIn": "Night Shift (1978)",
+    "notes": [],
+    "year": 1973,
+    "created_at": "2023-11-13T23:49:01.311Z",
+    "villains": []
+  },
+  {
+    "id": 44,
+    "title": "Trucks",
+    "type": "short story",
+    "handle": "trucks",
+    "originallyPublishedIn": "Cavalier (June 1973)",
+    "collectedIn": "Night Shift (1978)",
+    "notes": [],
+    "year": 1973,
+    "created_at": "2023-11-13T23:49:01.428Z",
+    "villains": []
+  },
+  {
+    "id": 45,
+    "title": "Gray Matter",
+    "type": "short story",
+    "handle": "gray-matter",
+    "originallyPublishedIn": "Cavalier (October 1973)",
+    "collectedIn": "Night Shift (1978)",
+    "notes": [],
+    "year": 1973,
+    "created_at": "2023-11-13T23:49:01.545Z",
+    "villains": []
+  },
+  {
+    "id": 46,
+    "title": "It Grows on You",
+    "type": "short story",
+    "handle": "it-grows-on-you",
+    "originallyPublishedIn": "Marshroots (Fall 1973)",
+    "collectedIn": "Nightmares & Dreamscapes (1993)",
+    "notes": [
+      "Republished revised in Whispers (August 1982), collected further revisedNominee, Locus Award, 1983[2]"
+    ],
+    "year": 1973,
+    "created_at": "2023-11-13T23:49:01.672Z",
+    "villains": []
+  },
+  {
+    "id": 47,
+    "title": "Sometimes They Come Back",
+    "type": "short story",
+    "handle": "sometimes-they-come-back",
+    "originallyPublishedIn": "Cavalier (March 1974)",
+    "collectedIn": "Night Shift (1978)",
+    "notes": [],
+    "year": 1974,
+    "created_at": "2023-11-13T23:49:01.794Z",
+    "villains": [
+      {
+        "name": "Richard Lawson",
+        "url": "https://stephen-king-api.onrender.com/api/villain/65"
+      }
+    ]
+  },
+  {
+    "id": 48,
+    "title": "The Lawnmower Man",
+    "type": "short story",
+    "handle": "the-lawnmower-man",
+    "originallyPublishedIn": "Cavalier (May 1975)",
+    "collectedIn": "Night Shift (1978)",
+    "notes": [],
+    "year": 1975,
+    "created_at": "2023-11-13T23:49:01.908Z",
+    "villains": []
+  },
+  {
+    "id": 49,
+    "title": "The Revenge of Lard Ass Hogan",
+    "type": "short story",
+    "handle": "the-revenge-of-lard-ass-hogan",
+    "originallyPublishedIn": "The Maine Review (July 1975)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Incorporated into The Body (1982)"
+    ],
+    "year": 1975,
+    "created_at": "2023-11-13T23:49:02.033Z",
+    "villains": []
+  },
+  {
+    "id": 50,
+    "title": "Weeds",
+    "type": "short story",
+    "handle": "weeds",
+    "originallyPublishedIn": "Cavalier (May 1976)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Appears in comic book form in Creepshow (1982) as The Lonesome Death of Jordy Verrill"
+    ],
+    "year": 1976,
+    "created_at": "2023-11-13T23:49:02.164Z",
+    "villains": []
+  },
+  {
+    "id": 51,
+    "title": "The Ledge",
+    "type": "short story",
+    "handle": "the-ledge",
+    "originallyPublishedIn": "Penthouse (July 1976)",
+    "collectedIn": "Night Shift (1978)",
+    "notes": [],
+    "year": 1976,
+    "created_at": "2023-11-13T23:49:02.284Z",
+    "villains": []
+  },
+  {
+    "id": 52,
+    "title": "I Know What You Need",
+    "type": "short story",
+    "handle": "i-know-what-you-need",
+    "originallyPublishedIn": "Cosmopolitan (September 1976)",
+    "collectedIn": "Night Shift (1978)",
+    "notes": [],
+    "year": 1976,
+    "created_at": "2023-11-13T23:49:02.408Z",
+    "villains": []
+  },
+  {
+    "id": 53,
+    "title": "Children of the Corn",
+    "type": "short story",
+    "handle": "children-of-the-corn",
+    "originallyPublishedIn": "Penthouse (March 1977)",
+    "collectedIn": "Night Shift (1978)",
+    "notes": [],
+    "year": 1977,
+    "created_at": "2023-11-13T23:49:02.530Z",
+    "villains": [
+      {
+        "name": "Malachai Boardman",
+        "url": "https://stephen-king-api.onrender.com/api/villain/5"
+      },
+      {
+        "name": "Isaac Chroner",
+        "url": "https://stephen-king-api.onrender.com/api/villain/12"
+      }
+    ]
+  },
+  {
+    "id": 54,
+    "title": "One for the Road",
+    "type": "short story",
+    "handle": "one-for-the-road",
+    "originallyPublishedIn": "Maine (March/April 1977)",
+    "collectedIn": "Night Shift (1978)",
+    "notes": [],
+    "year": 1977,
+    "created_at": "2023-11-13T23:49:02.645Z",
+    "villains": []
+  },
+  {
+    "id": 55,
+    "title": "The Cat from Hell",
+    "type": "short story",
+    "handle": "the-cat-from-hell",
+    "originallyPublishedIn": "Cavalier (June 1977)",
+    "collectedIn": "Just After Sunset (2008)",
+    "notes": [],
+    "year": 1977,
+    "created_at": "2023-11-13T23:49:02.760Z",
+    "villains": [
+      {
+        "name": "John Halston",
+        "url": "https://stephen-king-api.onrender.com/api/villain/47"
+      },
+      {
+        "name": "Sam (cat)",
+        "url": "https://stephen-king-api.onrender.com/api/villain/92"
+      }
+    ]
+  },
+  {
+    "id": 56,
+    "title": "The King Family and the Wicked Witch",
+    "type": "short story",
+    "handle": "the-king-family-and-the-wicked-witch",
+    "originallyPublishedIn": "Flint (August 25, 1977)",
+    "collectedIn": "Uncollected",
+    "notes": [],
+    "year": 1977,
+    "created_at": "2023-11-13T23:49:02.876Z",
+    "villains": []
+  },
+  {
+    "id": 57,
+    "title": "The Man Who Loved Flowers",
+    "type": "short story",
+    "handle": "the-man-who-loved-flowers",
+    "originallyPublishedIn": "Gallery (August 1977)",
+    "collectedIn": "Night Shift (1978)",
+    "notes": [],
+    "year": 1977,
+    "created_at": "2023-11-13T23:49:03.137Z",
+    "villains": []
+  },
+  {
+    "id": 58,
+    "title": "Jerusalem's Lot",
+    "type": "short story",
+    "handle": "jerusalem-s-lot",
+    "originallyPublishedIn": "Night Shift (February 1978)",
+    "collectedIn": "Night Shift (1978)",
+    "notes": [],
+    "year": 1978,
+    "created_at": "2023-11-13T23:49:03.269Z",
+    "villains": [
+      {
+        "name": "James Boon",
+        "url": "https://stephen-king-api.onrender.com/api/villain/6"
+      }
+    ]
+  },
+  {
+    "id": 59,
+    "title": "The Last Rung on the Ladder",
+    "type": "short story",
+    "handle": "the-last-rung-on-the-ladder",
+    "originallyPublishedIn": "Night Shift (February 1978)",
+    "collectedIn": "Night Shift (1978)",
+    "notes": [],
+    "year": 1978,
+    "created_at": "2023-11-13T23:49:03.401Z",
+    "villains": []
+  },
+  {
+    "id": 60,
+    "title": "Quitters, Inc.",
+    "type": "short story",
+    "handle": "quitters-inc-",
+    "originallyPublishedIn": "Night Shift (February 1978)",
+    "collectedIn": "Night Shift (1978)",
+    "notes": [],
+    "year": 1978,
+    "created_at": "2023-11-13T23:49:03.529Z",
+    "villains": []
+  },
+  {
+    "id": 61,
+    "title": "The Woman in the Room",
+    "type": "short story",
+    "handle": "the-woman-in-the-room",
+    "originallyPublishedIn": "Night Shift (February 1978)",
+    "collectedIn": "Night Shift (1978)",
+    "notes": [],
+    "year": 1978,
+    "created_at": "2023-11-13T23:49:03.651Z",
+    "villains": []
+  },
+  {
+    "id": 62,
+    "title": "The Night of the Tiger",
+    "type": "short story",
+    "handle": "the-night-of-the-tiger",
+    "originallyPublishedIn": "The Magazine of Fantasy & Science Fiction (February 1978)",
+    "collectedIn": "Uncollected",
+    "notes": [],
+    "year": 1978,
+    "created_at": "2023-11-13T23:49:03.773Z",
+    "villains": []
+  },
+  {
+    "id": 63,
+    "title": "Nona",
+    "type": "short story",
+    "handle": "nona",
+    "originallyPublishedIn": "Shadows (September 1978)",
+    "collectedIn": "Skeleton Crew (1985)",
+    "notes": [],
+    "year": 1978,
+    "created_at": "2023-11-13T23:49:03.889Z",
+    "villains": []
+  },
+  {
+    "id": 64,
+    "title": "The Gunslinger",
+    "type": "novella",
+    "handle": "the-gunslinger",
+    "originallyPublishedIn": "The Magazine of Fantasy & Science Fiction (October 1978)",
+    "collectedIn": "The Dark Tower: The Gunslinger (1982)",
+    "notes": [
+      "Collected revised",
+      "Nominee, Locus Award, 1978[2]"
+    ],
+    "year": 1978,
+    "created_at": "2023-11-13T23:49:04.008Z",
+    "villains": []
+  },
+  {
+    "id": 65,
+    "title": "Man With a Belly",
+    "type": "short story",
+    "handle": "man-with-a-belly",
+    "originallyPublishedIn": "Cavalier (December 1978)",
+    "collectedIn": "Uncollected",
+    "notes": [],
+    "year": 1978,
+    "created_at": "2023-11-13T23:49:04.130Z",
+    "villains": []
+  },
+  {
+    "id": 66,
+    "title": "The Crate",
+    "type": "short story",
+    "handle": "the-crate",
+    "originallyPublishedIn": "Gallery (July 1979)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Appears in comic book form in Creepshow (1982)Nominee, Locus Award, 1980[2]"
+    ],
+    "year": 1979,
+    "created_at": "2023-11-13T23:49:04.251Z",
+    "villains": []
+  },
+  {
+    "id": 67,
+    "title": "The Mist",
+    "type": "novella",
+    "handle": "the-mist",
+    "originallyPublishedIn": "Dark Forces (January 1, 1980)",
+    "collectedIn": "Skeleton Crew (1985)",
+    "notes": [
+      "Nominee, World Fantasy Award, 1981",
+      "Nominee, Locus Award, 1981[2]"
+    ],
+    "year": 1980,
+    "created_at": "2023-11-13T23:49:04.363Z",
+    "villains": []
+  },
+  {
+    "id": 68,
+    "title": "Crouch End",
+    "type": "short story",
+    "handle": "crouch-end",
+    "originallyPublishedIn": "New Tales of the Cthulhu Mythos (January 1980)",
+    "collectedIn": "Nightmares & Dreamscapes (1993)",
+    "notes": [
+      "Nominee, British Fantasy Award, 1981[2]"
+    ],
+    "year": 1980,
+    "created_at": "2023-11-13T23:49:04.505Z",
+    "villains": []
+  },
+  {
+    "id": 69,
+    "title": "The Way Station",
+    "type": "novella",
+    "handle": "the-way-station",
+    "originallyPublishedIn": "The Magazine of Fantasy & Science Fiction (April 1980)",
+    "collectedIn": "The Dark Tower: The Gunslinger (1982)",
+    "notes": [
+      "Collected revised",
+      "Nominee, Nebula Award,1981",
+      "Nominee, Locus Award, 1981[2]"
+    ],
+    "year": 1980,
+    "created_at": "2023-11-13T23:49:04.673Z",
+    "villains": []
+  },
+  {
+    "id": 70,
+    "title": "Big Wheels: A Tale of the Laundry Game (Milkman #2)",
+    "type": "short story",
+    "handle": "big-wheels-a-tale-of-the-laundry-game-milkman-2-",
+    "originallyPublishedIn": "New Terrors (July 1980)",
+    "collectedIn": "Skeleton Crew (1985)",
+    "notes": [],
+    "year": 1980,
+    "created_at": "2023-11-13T23:49:04.800Z",
+    "villains": []
+  },
+  {
+    "id": 71,
+    "title": "The Monkey",
+    "type": "short story",
+    "handle": "the-monkey",
+    "originallyPublishedIn": "Gallery (November 1980)",
+    "collectedIn": "Skeleton Crew (1985)",
+    "notes": [
+      "Collected heavily revised",
+      "Nominee, British Fantasy Award, 1982[2]"
+    ],
+    "year": 1980,
+    "created_at": "2023-11-13T23:49:04.929Z",
+    "villains": []
+  },
+  {
+    "id": 72,
+    "title": "The Wedding Gig",
+    "type": "short story",
+    "handle": "the-wedding-gig",
+    "originallyPublishedIn": "Ellery Queen's Mystery Magazine (December 1980)",
+    "collectedIn": "Skeleton Crew (1985)",
+    "notes": [],
+    "year": 1980,
+    "created_at": "2023-11-13T23:49:05.066Z",
+    "villains": []
+  },
+  {
+    "id": 73,
+    "title": "The Oracle and the Mountains",
+    "type": "novella",
+    "handle": "the-oracle-and-the-mountains",
+    "originallyPublishedIn": "The Magazine of Fantasy & Science Fiction (February 1981)",
+    "collectedIn": "The Dark Tower: The Gunslinger (1982)",
+    "notes": [
+      "Collected revised"
+    ],
+    "year": 1981,
+    "created_at": "2023-11-13T23:49:05.187Z",
+    "villains": []
+  },
+  {
+    "id": 74,
+    "title": "The Jaunt",
+    "type": "short story",
+    "handle": "the-jaunt",
+    "originallyPublishedIn": "The Twilight Zone Magazine (June 1981)",
+    "collectedIn": "Skeleton Crew (1985)",
+    "notes": [],
+    "year": 1981,
+    "created_at": "2023-11-13T23:49:05.359Z",
+    "villains": []
+  },
+  {
+    "id": 75,
+    "title": "The Slow Mutants",
+    "type": "novella",
+    "handle": "the-slow-mutants",
+    "originallyPublishedIn": "The Magazine of Fantasy & Science Fiction (July 1981)",
+    "collectedIn": "The Dark Tower: The Gunslinger (1982)",
+    "notes": [
+      "Collected revised"
+    ],
+    "year": 1981,
+    "created_at": "2023-11-13T23:49:05.477Z",
+    "villains": []
+  },
+  {
+    "id": 76,
+    "title": "The Man Who Would Not Shake Hands",
+    "type": "short story",
+    "handle": "the-man-who-would-not-shake-hands",
+    "originallyPublishedIn": "Shadows 4 (October 1981)",
+    "collectedIn": "Skeleton Crew (1985)",
+    "notes": [],
+    "year": 1981,
+    "created_at": "2023-11-13T23:49:05.666Z",
+    "villains": []
+  },
+  {
+    "id": 77,
+    "title": "The Monster in the Closet",
+    "type": "short story",
+    "handle": "the-monster-in-the-closet",
+    "originallyPublishedIn": "Ladies' Home Journal (October 1981)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Incorporated into Cujo (1981)"
+    ],
+    "year": 1981,
+    "created_at": "2023-11-13T23:49:05.875Z",
+    "villains": []
+  },
+  {
+    "id": 78,
+    "title": "The Bird and the Album",
+    "type": "short story",
+    "handle": "the-bird-and-the-album",
+    "originallyPublishedIn": "A Fantasy Reader (October 30, 1981)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Incorporated into It (1986)"
+    ],
+    "year": 1981,
+    "created_at": "2023-11-13T23:49:06.053Z",
+    "villains": []
+  },
+  {
+    "id": 79,
+    "title": "The Gunslinger and the Dark Man",
+    "type": "novella",
+    "handle": "the-gunslinger-and-the-dark-man",
+    "originallyPublishedIn": "The Magazine of Fantasy & Science Fiction (November 1981)",
+    "collectedIn": "The Dark Tower: The Gunslinger (1982)",
+    "notes": [
+      "Collected revised"
+    ],
+    "year": 1981,
+    "created_at": "2023-11-13T23:49:06.176Z",
+    "villains": []
+  },
+  {
+    "id": 80,
+    "title": "The Reach",
+    "type": "short story",
+    "handle": "the-reach",
+    "originallyPublishedIn": "Yankee (November 1981)",
+    "collectedIn": "Skeleton Crew (1985)",
+    "notes": [
+      "Originally titled Do the Dead Sing?Nominee, World Fantasy Award, 1982[2]"
+    ],
+    "year": 1981,
+    "created_at": "2023-11-13T23:49:06.292Z",
+    "villains": []
+  },
+  {
+    "id": 81,
+    "title": "Survivor Type",
+    "type": "short story",
+    "handle": "survivor-type",
+    "originallyPublishedIn": "Terrors (July 1982)",
+    "collectedIn": "Skeleton Crew (1985)",
+    "notes": [],
+    "year": 1982,
+    "created_at": "2023-11-13T23:49:06.409Z",
+    "villains": []
+  },
+  {
+    "id": 82,
+    "title": "Before the Play",
+    "type": "short story",
+    "handle": "before-the-play",
+    "originallyPublishedIn": "Whispers (August 1982)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Unused prologue to The Shining (1977)"
+    ],
+    "year": 1982,
+    "created_at": "2023-11-13T23:49:06.526Z",
+    "villains": []
+  },
+  {
+    "id": 83,
+    "title": "Apt Pupil",
+    "type": "novella",
+    "handle": "apt-pupil",
+    "originallyPublishedIn": "Different Seasons (August 27, 1982)",
+    "collectedIn": "Different Seasons (1982)",
+    "notes": [
+      "Nominee, British Fantasy Award, 1983[2]"
+    ],
+    "year": 1982,
+    "created_at": "2023-11-13T23:49:06.643Z",
+    "villains": [
+      {
+        "name": "Kurt Dussander",
+        "url": "https://stephen-king-api.onrender.com/api/villain/33"
+      }
+    ]
+  },
+  {
+    "id": 84,
+    "title": "The Body",
+    "type": "novella",
+    "handle": "the-body",
+    "originallyPublishedIn": "Different Seasons (August 27, 1982)",
+    "collectedIn": "Different Seasons (1982)",
+    "notes": [],
+    "year": 1982,
+    "created_at": "2023-11-13T23:49:06.765Z",
+    "villains": [
+      {
+        "name": "John \"Ace\" Merrill",
+        "url": "https://stephen-king-api.onrender.com/api/villain/74"
+      }
+    ]
+  },
+  {
+    "id": 85,
+    "title": "The Breathing Method",
+    "type": "novella",
+    "handle": "the-breathing-method",
+    "originallyPublishedIn": "Different Seasons (August 27, 1982)",
+    "collectedIn": "Different Seasons (1982)",
+    "notes": [
+      "Winner, British Fantasy Award, 1983",
+      "Nominee, World Fantasy Award, 1983",
+      "Nominee, Locus Award, 1983[2]"
+    ],
+    "year": 1982,
+    "created_at": "2023-11-13T23:49:06.881Z",
+    "villains": []
+  },
+  {
+    "id": 86,
+    "title": "Rita Hayworth and Shawshank Redemption",
+    "type": "novella",
+    "handle": "rita-hayworth-and-shawshank-redemption",
+    "originallyPublishedIn": "Different Seasons (August 27, 1982)",
+    "collectedIn": "Different Seasons (1982)",
+    "notes": [],
+    "year": 1982,
+    "created_at": "2023-11-13T23:49:06.996Z",
+    "villains": [
+      {
+        "name": "Bogs Diamond",
+        "url": "https://stephen-king-api.onrender.com/api/villain/28"
+      },
+      {
+        "name": "Byron Hadley",
+        "url": "https://stephen-king-api.onrender.com/api/villain/46"
+      },
+      {
+        "name": "Samuel Norton",
+        "url": "https://stephen-king-api.onrender.com/api/villain/81"
+      },
+      {
+        "name": "Tim Youngblood",
+        "url": "https://stephen-king-api.onrender.com/api/villain/115"
+      }
+    ]
+  },
+  {
+    "id": 87,
+    "title": "The Raft",
+    "type": "short story",
+    "handle": "the-raft",
+    "originallyPublishedIn": "Gallery (November 1982)",
+    "collectedIn": "Skeleton Crew (1985)",
+    "notes": [
+      "Nominee, Locus Award, 1983[2]"
+    ],
+    "year": 1982,
+    "created_at": "2023-11-13T23:49:07.113Z",
+    "villains": []
+  },
+  {
+    "id": 88,
+    "title": "Skybar",
+    "type": "short story",
+    "handle": "skybar",
+    "originallyPublishedIn": "The Do-It-Yourself Bestseller (1982)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Partial short story"
+    ],
+    "year": 1982,
+    "created_at": "2023-11-13T23:49:07.224Z",
+    "villains": []
+  },
+  {
+    "id": 89,
+    "title": "Word Processor of the Gods",
+    "type": "short story",
+    "handle": "word-processor-of-the-gods",
+    "originallyPublishedIn": "Playboy (January 1983)",
+    "collectedIn": "Skeleton Crew (1985)",
+    "notes": [
+      "Originally titled The Word Processor",
+      " collected heavily revised"
+    ],
+    "year": 1983,
+    "created_at": "2023-11-13T23:49:07.336Z",
+    "villains": []
+  },
+  {
+    "id": 90,
+    "title": "Uncle Otto's Truck",
+    "type": "short story",
+    "handle": "uncle-otto-s-truck",
+    "originallyPublishedIn": "Yankee (October 1983)",
+    "collectedIn": "Skeleton Crew (1985)",
+    "notes": [],
+    "year": 1983,
+    "created_at": "2023-11-13T23:49:07.450Z",
+    "villains": []
+  },
+  {
+    "id": 91,
+    "title": "Cycle of the Werewolf",
+    "type": "novella",
+    "handle": "cycle-of-the-werewolf",
+    "originallyPublishedIn": "Land of Enchantment (November 1983)",
+    "collectedIn": "Uncollected (standalone book)",
+    "notes": [],
+    "year": 1983,
+    "created_at": "2023-11-13T23:49:07.598Z",
+    "villains": [
+      {
+        "name": "Lester Lowe",
+        "url": "https://stephen-king-api.onrender.com/api/villain/68"
+      }
+    ]
+  },
+  {
+    "id": 92,
+    "title": "The Return of Timmy Baterman",
+    "type": "short story",
+    "handle": "the-return-of-timmy-baterman",
+    "originallyPublishedIn": "Satyricon II (1983)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Incorporated into Pet Sematary (1983)"
+    ],
+    "year": 1983,
+    "created_at": "2023-11-13T23:49:07.714Z",
+    "villains": []
+  },
+  {
+    "id": 93,
+    "title": "Gramma",
+    "type": "short story",
+    "handle": "gramma",
+    "originallyPublishedIn": "Weirdbook (Spring 1984)",
+    "collectedIn": "Skeleton Crew (1985)",
+    "notes": [],
+    "year": 1984,
+    "created_at": "2023-11-13T23:49:07.827Z",
+    "villains": []
+  },
+  {
+    "id": 94,
+    "title": "Mrs. Todd's Shortcut",
+    "type": "short story",
+    "handle": "mrs-todd-s-shortcut",
+    "originallyPublishedIn": "Redbook (May 1984)",
+    "collectedIn": "Skeleton Crew (1985)",
+    "notes": [],
+    "year": 1984,
+    "created_at": "2023-11-13T23:49:07.949Z",
+    "villains": []
+  },
+  {
+    "id": 95,
+    "title": "The Ballad of the Flexible Bullet",
+    "type": "novella",
+    "handle": "the-ballad-of-the-flexible-bullet",
+    "originallyPublishedIn": "The Magazine of Fantasy & Science Fiction (June 1984)",
+    "collectedIn": "Skeleton Crew (1985)",
+    "notes": [
+      "Nominee, World Fantasy Award, 1985",
+      "Nominee, Locus Award, 1985[2]"
+    ],
+    "year": 1984,
+    "created_at": "2023-11-13T23:49:08.062Z",
+    "villains": []
+  },
+  {
+    "id": 96,
+    "title": "The Revelations of 'Becka Paulson",
+    "type": "short story",
+    "handle": "the-revelations-of-becka-paulson",
+    "originallyPublishedIn": "Rolling Stone (July 19 – August 2, 1984)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Collected in the limited edition of Skeleton Crew (1985)",
+      "incorporated into The Tommyknockers (1987)"
+    ],
+    "year": 1984,
+    "created_at": "2023-11-13T23:49:08.176Z",
+    "villains": []
+  },
+  {
+    "id": 97,
+    "title": "Beachworld",
+    "type": "short story",
+    "handle": "beachworld",
+    "originallyPublishedIn": "Weird Tales (Fall 1984)",
+    "collectedIn": "Skeleton Crew (1985)",
+    "notes": [],
+    "year": 1984,
+    "created_at": "2023-11-13T23:49:08.291Z",
+    "villains": []
+  },
+  {
+    "id": 98,
+    "title": "Dolan's Cadillac",
+    "type": "novella",
+    "handle": "dolan-s-cadillac",
+    "originallyPublishedIn": "Castle Rock (February – June 1985)",
+    "collectedIn": "Nightmares & Dreamscapes (1993)",
+    "notes": [],
+    "year": 1985,
+    "created_at": "2023-11-13T23:49:08.405Z",
+    "villains": []
+  },
+  {
+    "id": 99,
+    "title": "For Owen",
+    "type": "poem",
+    "handle": "for-owen",
+    "originallyPublishedIn": "Skeleton Crew (June 1985)",
+    "collectedIn": "Skeleton Crew (1985)",
+    "notes": [],
+    "year": 1985,
+    "created_at": "2023-11-13T23:49:08.524Z",
+    "villains": []
+  },
+  {
+    "id": 100,
+    "title": "Morning Deliveries (Milkman #1)",
+    "type": "short story",
+    "handle": "morning-deliveries-milkman-1-",
+    "originallyPublishedIn": "Skeleton Crew (June 1985)",
+    "collectedIn": "Skeleton Crew (1985)",
+    "notes": [],
+    "year": 1985,
+    "created_at": "2023-11-13T23:49:08.643Z",
+    "villains": []
+  },
+  {
+    "id": 101,
+    "title": "Paranoid: A Chant",
+    "type": "poem",
+    "handle": "paranoid-a-chant",
+    "originallyPublishedIn": "Skeleton Crew (June 1985)",
+    "collectedIn": "Skeleton Crew (1985)",
+    "notes": [],
+    "year": 1985,
+    "created_at": "2023-11-13T23:49:08.760Z",
+    "villains": []
+  },
+  {
+    "id": 102,
+    "title": "For the Birds",
+    "type": "short story",
+    "handle": "for-the-birds",
+    "originallyPublishedIn": "Bred Any Good Rooks Lately? (January 1986)",
+    "collectedIn": "Uncollected",
+    "notes": [],
+    "year": 1986,
+    "created_at": "2023-11-13T23:49:08.884Z",
+    "villains": []
+  },
+  {
+    "id": 103,
+    "title": "The End of the Whole Mess",
+    "type": "short story",
+    "handle": "the-end-of-the-whole-mess",
+    "originallyPublishedIn": "Omni (October 1986)",
+    "collectedIn": "Nightmares & Dreamscapes (1993)",
+    "notes": [
+      "Nominee, World Fantasy Award, 1987[2]"
+    ],
+    "year": 1986,
+    "created_at": "2023-11-13T23:49:09.002Z",
+    "villains": []
+  },
+  {
+    "id": 104,
+    "title": "Popsy",
+    "type": "short story",
+    "handle": "popsy",
+    "originallyPublishedIn": "Masques II (June 1987)",
+    "collectedIn": "Nightmares & Dreamscapes (1993)",
+    "notes": [],
+    "year": 1987,
+    "created_at": "2023-11-13T23:49:09.124Z",
+    "villains": []
+  },
+  {
+    "id": 105,
+    "title": "The Doctor's Case",
+    "type": "short story",
+    "handle": "the-doctor-s-case",
+    "originallyPublishedIn": "The New Adventures of Sherlock Holmes (November 1987)",
+    "collectedIn": "Nightmares & Dreamscapes (1993)",
+    "notes": [],
+    "year": 1987,
+    "created_at": "2023-11-13T23:49:09.240Z",
+    "villains": []
+  },
+  {
+    "id": 106,
+    "title": "The Night Flier",
+    "type": "short story",
+    "handle": "the-night-flier",
+    "originallyPublishedIn": "Prime Evil (June 1988)",
+    "collectedIn": "Nightmares & Dreamscapes (1993)",
+    "notes": [
+      "Nominee, Bram Stoker Award, 1989[2]"
+    ],
+    "year": 1988,
+    "created_at": "2023-11-13T23:49:09.354Z",
+    "villains": []
+  },
+  {
+    "id": 107,
+    "title": "Dedication",
+    "type": "short story",
+    "handle": "dedication",
+    "originallyPublishedIn": "Night Visions 5 (August 1988)",
+    "collectedIn": "Nightmares & Dreamscapes (1993)",
+    "notes": [],
+    "year": 1988,
+    "created_at": "2023-11-13T23:49:09.469Z",
+    "villains": []
+  },
+  {
+    "id": 108,
+    "title": "The Reploids",
+    "type": "short story",
+    "handle": "the-reploids",
+    "originallyPublishedIn": "Night Visions 5 (August 1988)",
+    "collectedIn": "Uncollected",
+    "notes": [],
+    "year": 1988,
+    "created_at": "2023-11-13T23:49:09.585Z",
+    "villains": []
+  },
+  {
+    "id": 109,
+    "title": "Sneakers",
+    "type": "short story",
+    "handle": "sneakers",
+    "originallyPublishedIn": "Night Visions 5 (August 1988)",
+    "collectedIn": "Nightmares & Dreamscapes (1993)",
+    "notes": [],
+    "year": 1988,
+    "created_at": "2023-11-13T23:49:09.699Z",
+    "villains": []
+  },
+  {
+    "id": 110,
+    "title": "Rainy Season",
+    "type": "short story",
+    "handle": "rainy-season",
+    "originallyPublishedIn": "Midnight Graffiti (Spring 1989)",
+    "collectedIn": "Nightmares & Dreamscapes (1993)",
+    "notes": [],
+    "year": 1989,
+    "created_at": "2023-11-13T23:49:09.819Z",
+    "villains": []
+  },
+  {
+    "id": 111,
+    "title": "Home Delivery",
+    "type": "short story",
+    "handle": "home-delivery",
+    "originallyPublishedIn": "Book of the Dead (June 1989)",
+    "collectedIn": "Nightmares & Dreamscapes (1993)",
+    "notes": [],
+    "year": 1989,
+    "created_at": "2023-11-13T23:49:09.928Z",
+    "villains": []
+  },
+  {
+    "id": 112,
+    "title": "My Pretty Pony",
+    "type": "short story",
+    "handle": "my-pretty-pony",
+    "originallyPublishedIn": "My Pretty Pony (September 1989)",
+    "collectedIn": "Nightmares & Dreamscapes (1993)",
+    "notes": [
+      "Collected revised"
+    ],
+    "year": 1989,
+    "created_at": "2023-11-13T23:49:10.052Z",
+    "villains": []
+  },
+  {
+    "id": 113,
+    "title": "An Evening at God's",
+    "type": "play",
+    "handle": "an-evening-at-god-s",
+    "originallyPublishedIn": "Institute for Advanced Theater Training (April 23, 1990)",
+    "collectedIn": "Uncollected",
+    "notes": [],
+    "year": 1990,
+    "created_at": "2023-11-13T23:49:10.164Z",
+    "villains": []
+  },
+  {
+    "id": 114,
+    "title": "The Langoliers",
+    "type": "novella",
+    "handle": "the-langoliers",
+    "originallyPublishedIn": "Four Past Midnight (September 1990)",
+    "collectedIn": "Four Past Midnight (1990)",
+    "notes": [
+      "Nominee, Bram Stoker Award, 1991[2]"
+    ],
+    "year": 1990,
+    "created_at": "2023-11-13T23:49:10.278Z",
+    "villains": [
+      {
+        "name": "Craig Toomey",
+        "url": "https://stephen-king-api.onrender.com/api/villain/105"
+      }
+    ]
+  },
+  {
+    "id": 115,
+    "title": "The Library Policeman",
+    "type": "novella",
+    "handle": "the-library-policeman",
+    "originallyPublishedIn": "Four Past Midnight (September 1990)",
+    "collectedIn": "Four Past Midnight (1990)",
+    "notes": [],
+    "year": 1990,
+    "created_at": "2023-11-13T23:49:10.391Z",
+    "villains": []
+  },
+  {
+    "id": 116,
+    "title": "Secret Window, Secret Garden",
+    "type": "novella",
+    "handle": "secret-window-secret-garden",
+    "originallyPublishedIn": "Four Past Midnight (September 1990)",
+    "collectedIn": "Four Past Midnight (1990)",
+    "notes": [],
+    "year": 1990,
+    "created_at": "2023-11-13T23:49:10.514Z",
+    "villains": []
+  },
+  {
+    "id": 117,
+    "title": "The Sun Dog",
+    "type": "novella",
+    "handle": "the-sun-dog",
+    "originallyPublishedIn": "Four Past Midnight (September 1990)",
+    "collectedIn": "Four Past Midnight (1990)",
+    "notes": [],
+    "year": 1990,
+    "created_at": "2023-11-13T23:49:10.643Z",
+    "villains": []
+  },
+  {
+    "id": 118,
+    "title": "The Bear",
+    "type": "short story",
+    "handle": "the-bear",
+    "originallyPublishedIn": "The Magazine of Fantasy & Science Fiction (December 1990)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Incorporated into The Dark Tower III: The Waste Lands (1991)"
+    ],
+    "year": 1990,
+    "created_at": "2023-11-13T23:49:10.760Z",
+    "villains": []
+  },
+  {
+    "id": 119,
+    "title": "The Moving Finger",
+    "type": "short story",
+    "handle": "the-moving-finger",
+    "originallyPublishedIn": "The Magazine of Fantasy & Science Fiction (December 1990)",
+    "collectedIn": "Nightmares & Dreamscapes (1993)",
+    "notes": [],
+    "year": 1990,
+    "created_at": "2023-11-13T23:49:10.873Z",
+    "villains": []
+  },
+  {
+    "id": 120,
+    "title": "You Know They Got a Hell of a Band",
+    "type": "short story",
+    "handle": "you-know-they-got-a-hell-of-a-band",
+    "originallyPublishedIn": "Shock Rock (January 1992)",
+    "collectedIn": "Nightmares & Dreamscapes (1993)",
+    "notes": [
+      "Collected heavily revised"
+    ],
+    "year": 1992,
+    "created_at": "2023-11-13T23:49:10.987Z",
+    "villains": []
+  },
+  {
+    "id": 121,
+    "title": "Chattery Teeth",
+    "type": "short story",
+    "handle": "chattery-teeth",
+    "originallyPublishedIn": "Cemetery Dance (Fall 1992)",
+    "collectedIn": "Nightmares & Dreamscapes (1993)",
+    "notes": [],
+    "year": 1992,
+    "created_at": "2023-11-13T23:49:11.108Z",
+    "villains": []
+  },
+  {
+    "id": 122,
+    "title": "The Beggar and the Diamond",
+    "type": "short story",
+    "handle": "the-beggar-and-the-diamond",
+    "originallyPublishedIn": "Nightmares & Dreamscapes (September 1993)",
+    "collectedIn": "Nightmares & Dreamscapes (1993)",
+    "notes": [],
+    "year": 1993,
+    "created_at": "2023-11-13T23:49:11.227Z",
+    "villains": []
+  },
+  {
+    "id": 123,
+    "title": "The House on Maple Street",
+    "type": "short story",
+    "handle": "the-house-on-maple-street",
+    "originallyPublishedIn": "Nightmares & Dreamscapes (September 1993)",
+    "collectedIn": "Nightmares & Dreamscapes (1993)",
+    "notes": [],
+    "year": 1993,
+    "created_at": "2023-11-13T23:49:11.348Z",
+    "villains": []
+  },
+  {
+    "id": 124,
+    "title": "Sorry, Right Number",
+    "type": "teleplay",
+    "handle": "sorry-right-number",
+    "originallyPublishedIn": "Nightmares & Dreamscapes (September 1993)",
+    "collectedIn": "Nightmares & Dreamscapes (1993)",
+    "notes": [
+      "Written in 1987"
+    ],
+    "year": 1993,
+    "created_at": "2023-11-13T23:49:11.470Z",
+    "villains": []
+  },
+  {
+    "id": 125,
+    "title": "The Ten O'Clock People",
+    "type": "short story",
+    "handle": "the-ten-o-clock-people",
+    "originallyPublishedIn": "Nightmares & Dreamscapes (September 1993)",
+    "collectedIn": "Nightmares & Dreamscapes (1993)",
+    "notes": [
+      "Nominee, Locus Award, 1994[2]"
+    ],
+    "year": 1993,
+    "created_at": "2023-11-13T23:49:11.582Z",
+    "villains": []
+  },
+  {
+    "id": 126,
+    "title": "Umney's Last Case",
+    "type": "short story",
+    "handle": "umney-s-last-case",
+    "originallyPublishedIn": "Nightmares & Dreamscapes (September 1993)",
+    "collectedIn": "Nightmares & Dreamscapes (1993)",
+    "notes": [],
+    "year": 1993,
+    "created_at": "2023-11-13T23:49:11.688Z",
+    "villains": []
+  },
+  {
+    "id": 127,
+    "title": "Jhonathan and the Witches",
+    "type": "short story",
+    "handle": "jhonathan-and-the-witches",
+    "originallyPublishedIn": "First Words (October 1993)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Written in 1956"
+    ],
+    "year": 1993,
+    "created_at": "2023-11-13T23:49:11.809Z",
+    "villains": []
+  },
+  {
+    "id": 128,
+    "title": "The Killer",
+    "type": "short story",
+    "handle": "the-killer",
+    "originallyPublishedIn": "Famous Monsters of Filmland #202 (Spring 1994)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Written in the mid-1960s"
+    ],
+    "year": 1994,
+    "created_at": "2023-11-13T23:49:11.924Z",
+    "villains": []
+  },
+  {
+    "id": 129,
+    "title": "Blind Willie",
+    "type": "short story",
+    "handle": "blind-willie",
+    "originallyPublishedIn": "Antaeus #75/76 (October 1994)",
+    "collectedIn": "Hearts in Atlantis (1999)",
+    "notes": [
+      "Collected heavily revised"
+    ],
+    "year": 1994,
+    "created_at": "2023-11-13T23:49:12.033Z",
+    "villains": []
+  },
+  {
+    "id": 130,
+    "title": "The Man in the Black Suit",
+    "type": "short story",
+    "handle": "the-man-in-the-black-suit",
+    "originallyPublishedIn": "The New Yorker (October 31, 1994)",
+    "collectedIn": "Everything's Eventual (2002)",
+    "notes": [
+      "Winner, World Fantasy Award, 1995[2]"
+    ],
+    "year": 1994,
+    "created_at": "2023-11-13T23:49:12.144Z",
+    "villains": []
+  },
+  {
+    "id": 131,
+    "title": "Dino",
+    "type": "poem",
+    "handle": "dino",
+    "originallyPublishedIn": "Salt Hill Journal (Fall 1994)",
+    "collectedIn": "Uncollected",
+    "notes": [],
+    "year": 1994,
+    "created_at": "2023-11-13T23:49:12.269Z",
+    "villains": []
+  },
+  {
+    "id": 132,
+    "title": "Luckey Quarter",
+    "type": "short story",
+    "handle": "luckey-quarter",
+    "originallyPublishedIn": "USA Weekend (June 30 – July 2, 1995)",
+    "collectedIn": "Everything's Eventual (2002)",
+    "notes": [],
+    "year": 1995,
+    "created_at": "2023-11-13T23:49:12.384Z",
+    "villains": []
+  },
+  {
+    "id": 173,
+    "title": "The Bone Church",
+    "type": "poem",
+    "handle": "the-bone-church",
+    "originallyPublishedIn": "Playboy (November 2009)",
+    "collectedIn": "The Bazaar of Bad Dreams (2015)",
+    "notes": [],
+    "year": 2009,
+    "created_at": "2023-11-13T23:49:17.542Z",
+    "villains": []
+  },
+  {
+    "id": 133,
+    "title": "Lunch at the Gotham Café",
+    "type": "short story",
+    "handle": "lunch-at-the-gotham-café",
+    "originallyPublishedIn": "Dark Love (November 1995)",
+    "collectedIn": "Everything's Eventual (2002)",
+    "notes": [
+      "Winner, Bram Stoker Award, 1996",
+      "Nominee, Locus Award, 1996[2]"
+    ],
+    "year": 1995,
+    "created_at": "2023-11-13T23:49:12.506Z",
+    "villains": []
+  },
+  {
+    "id": 134,
+    "title": "Autopsy Room Four",
+    "type": "short story",
+    "handle": "autopsy-room-four",
+    "originallyPublishedIn": "Six Stories (April 1997)",
+    "collectedIn": "Everything's Eventual (2002)",
+    "notes": [
+      "Nominee, Bram Stoker Award, 1999[2]"
+    ],
+    "year": 1997,
+    "created_at": "2023-11-13T23:49:12.619Z",
+    "villains": []
+  },
+  {
+    "id": 135,
+    "title": "L. T.'s Theory of Pets",
+    "type": "short story",
+    "handle": "l-t-s-theory-of-pets",
+    "originallyPublishedIn": "Six Stories (April 1997)",
+    "collectedIn": "Everything's Eventual (2002)",
+    "notes": [],
+    "year": 1997,
+    "created_at": "2023-11-13T23:49:12.743Z",
+    "villains": []
+  },
+  {
+    "id": 136,
+    "title": "General",
+    "type": "screenplay",
+    "handle": "general",
+    "originallyPublishedIn": "Screamplays  (September 1997)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Written around 1985 for the film Cat's Eye (1985)"
+    ],
+    "year": 1997,
+    "created_at": "2023-11-13T23:49:12.860Z",
+    "villains": []
+  },
+  {
+    "id": 137,
+    "title": "Everything's Eventual",
+    "type": "novella",
+    "handle": "everything-s-eventual",
+    "originallyPublishedIn": "The Magazine of Fantasy & Science Fiction (October–November 1997)",
+    "collectedIn": "Everything's Eventual (2002)",
+    "notes": [
+      "Nominee, Bram Stoker Award, 1998",
+      "Nominee, Locus Award, 1998[2]"
+    ],
+    "year": 1997,
+    "created_at": "2023-11-13T23:49:12.981Z",
+    "villains": []
+  },
+  {
+    "id": 138,
+    "title": "That Feeling, You Can Only Say What It Is in French",
+    "type": "short story",
+    "handle": "that-feeling-you-can-only-say-what-it-is-in-french",
+    "originallyPublishedIn": "The New Yorker (June 22, 1998)",
+    "collectedIn": "Everything's Eventual (2002)",
+    "notes": [],
+    "year": 1998,
+    "created_at": "2023-11-13T23:49:13.113Z",
+    "villains": []
+  },
+  {
+    "id": 139,
+    "title": "The Little Sisters of Eluria",
+    "type": "novella",
+    "handle": "the-little-sisters-of-eluria",
+    "originallyPublishedIn": "Legends (October 1998)",
+    "collectedIn": "Everything's Eventual (2002)",
+    "notes": [],
+    "year": 1998,
+    "created_at": "2023-11-13T23:49:13.225Z",
+    "villains": [
+      {
+        "name": "Little Sisters",
+        "url": "https://stephen-king-api.onrender.com/api/villain/67"
+      }
+    ]
+  },
+  {
+    "id": 140,
+    "title": "The New Lieutenant's Rap",
+    "type": "short story",
+    "handle": "the-new-lieutenant-s-rap",
+    "originallyPublishedIn": "The New Lieutenant's Rap (April 1999)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Incorporated into Why We're in Vietnam (1999)"
+    ],
+    "year": 1999,
+    "created_at": "2023-11-13T23:49:13.341Z",
+    "villains": []
+  },
+  {
+    "id": 141,
+    "title": "The Road Virus Heads North",
+    "type": "short story",
+    "handle": "the-road-virus-heads-north",
+    "originallyPublishedIn": "999 (September 7, 1999)",
+    "collectedIn": "Everything's Eventual (2002)",
+    "notes": [],
+    "year": 1999,
+    "created_at": "2023-11-13T23:49:13.464Z",
+    "villains": []
+  },
+  {
+    "id": 142,
+    "title": "Hearts in Atlantis",
+    "type": "novella",
+    "handle": "hearts-in-atlantis",
+    "originallyPublishedIn": "Hearts in Atlantis (September 14, 1999)",
+    "collectedIn": "Hearts in Atlantis (1999)",
+    "notes": [],
+    "year": 1999,
+    "created_at": "2023-11-13T23:49:13.588Z",
+    "villains": []
+  },
+  {
+    "id": 143,
+    "title": "Heavenly Shades of Night Are Falling",
+    "type": "short story",
+    "handle": "heavenly-shades-of-night-are-falling",
+    "originallyPublishedIn": "Hearts in Atlantis (September 14, 1999)",
+    "collectedIn": "Hearts in Atlantis (1999)",
+    "notes": [],
+    "year": 1999,
+    "created_at": "2023-11-13T23:49:13.718Z",
+    "villains": []
+  },
+  {
+    "id": 144,
+    "title": "Low Men in Yellow Coats",
+    "type": "novella",
+    "handle": "low-men-in-yellow-coats",
+    "originallyPublishedIn": "Hearts in Atlantis (September 14, 1999)",
+    "collectedIn": "Hearts in Atlantis (1999)",
+    "notes": [
+      "Nominee, Bram Stoker Award, 2000[2]"
+    ],
+    "year": 1999,
+    "created_at": "2023-11-13T23:49:13.849Z",
+    "villains": []
+  },
+  {
+    "id": 145,
+    "title": "Why We're in Vietnam",
+    "type": "novella",
+    "handle": "why-we-re-in-vietnam",
+    "originallyPublishedIn": "Hearts in Atlantis (September 14, 1999)",
+    "collectedIn": "Hearts in Atlantis (1999)",
+    "notes": [],
+    "year": 1999,
+    "created_at": "2023-11-13T23:49:13.969Z",
+    "villains": []
+  },
+  {
+    "id": 146,
+    "title": "1408",
+    "type": "short story",
+    "handle": "1408",
+    "originallyPublishedIn": "Blood and Smoke (November 1999)",
+    "collectedIn": "Everything's Eventual (2002)",
+    "notes": [
+      "Originally published in an audiobook collection"
+    ],
+    "year": 1999,
+    "created_at": "2023-11-13T23:49:14.111Z",
+    "villains": []
+  },
+  {
+    "id": 147,
+    "title": "In the Deathroom",
+    "type": "short story",
+    "handle": "in-the-deathroom",
+    "originallyPublishedIn": "Blood and Smoke (November 1999)",
+    "collectedIn": "Everything's Eventual (2002)",
+    "notes": [
+      "Originally published in an audiobook collection"
+    ],
+    "year": 1999,
+    "created_at": "2023-11-13T23:49:14.230Z",
+    "villains": []
+  },
+  {
+    "id": 148,
+    "title": "Riding the Bullet",
+    "type": "novella",
+    "handle": "riding-the-bullet",
+    "originallyPublishedIn": "Riding the Bullet (March 14, 2000)",
+    "collectedIn": "Everything's Eventual (2002)",
+    "notes": [
+      "Originally published as an ebookNominee, Bram Stoker Award, 2001[2]"
+    ],
+    "year": 2000,
+    "created_at": "2023-11-13T23:49:14.350Z",
+    "villains": []
+  },
+  {
+    "id": 149,
+    "title": "The Old Dude's Ticker",
+    "type": "short story",
+    "handle": "the-old-dude-s-ticker",
+    "originallyPublishedIn": "NECON XX (July 2000)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Written in the early 1970s"
+    ],
+    "year": 2000,
+    "created_at": "2023-11-13T23:49:14.472Z",
+    "villains": []
+  },
+  {
+    "id": 150,
+    "title": "All That You Love Will Be Carried Away",
+    "type": "short story",
+    "handle": "all-that-you-love-will-be-carried-away",
+    "originallyPublishedIn": "The New Yorker (January 29, 2001)",
+    "collectedIn": "Everything's Eventual (2002)",
+    "notes": [],
+    "year": 2001,
+    "created_at": "2023-11-13T23:49:14.601Z",
+    "villains": []
+  },
+  {
+    "id": 151,
+    "title": "Calla Bryn Sturgis",
+    "type": "short story",
+    "handle": "calla-bryn-sturgis",
+    "originallyPublishedIn": "stephenking.com (2001)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Incorporated into The Dark Tower V: Wolves of the Calla (2003)"
+    ],
+    "year": 2001,
+    "created_at": "2023-11-13T23:49:14.743Z",
+    "villains": []
+  },
+  {
+    "id": 152,
+    "title": "The Death of Jack Hamilton",
+    "type": "short story",
+    "handle": "the-death-of-jack-hamilton",
+    "originallyPublishedIn": "The New Yorker (December 24–31, 2001)",
+    "collectedIn": "Everything's Eventual (2002)",
+    "notes": [],
+    "year": 2001,
+    "created_at": "2023-11-13T23:49:14.889Z",
+    "villains": []
+  },
+  {
+    "id": 153,
+    "title": "The Tale of Gray Dick",
+    "type": "short story",
+    "handle": "the-tale-of-gray-dick",
+    "originallyPublishedIn": "McSweeney's Mammoth Treasury of Thrilling Tales (March 25, 2003)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Incorporated into The Dark Tower V: Wolves of the Calla (2003)"
+    ],
+    "year": 2003,
+    "created_at": "2023-11-13T23:49:15.033Z",
+    "villains": []
+  },
+  {
+    "id": 154,
+    "title": "Harvey's Dream",
+    "type": "short story",
+    "handle": "harvey-s-dream",
+    "originallyPublishedIn": "The New Yorker (June 30, 2003)",
+    "collectedIn": "Just After Sunset (2008)",
+    "notes": [
+      "Nominee, Bram Stoker Award, 2004[2]"
+    ],
+    "year": 2003,
+    "created_at": "2023-11-13T23:49:15.159Z",
+    "villains": []
+  },
+  {
+    "id": 155,
+    "title": "Stationary Bike",
+    "type": "short story",
+    "handle": "stationary-bike",
+    "originallyPublishedIn": "Borderlands 5 (November 2003)",
+    "collectedIn": "Just After Sunset (2008)",
+    "notes": [],
+    "year": 2003,
+    "created_at": "2023-11-13T23:49:15.280Z",
+    "villains": []
+  },
+  {
+    "id": 156,
+    "title": "Rest Stop",
+    "type": "short story",
+    "handle": "rest-stop",
+    "originallyPublishedIn": "Esquire (December 2003)",
+    "collectedIn": "Just After Sunset (2008)",
+    "notes": [],
+    "year": 2003,
+    "created_at": "2023-11-13T23:49:15.396Z",
+    "villains": []
+  },
+  {
+    "id": 157,
+    "title": "Lisey and the Madman",
+    "type": "short story",
+    "handle": "lisey-and-the-madman",
+    "originallyPublishedIn": "McSweeney’s Enchanted Chamber of Astonishing Stories (2004)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Incorporated into Lisey's Story (2006)Nominee, Bram Stoker Award, 2005[2]"
+    ],
+    "year": 2004,
+    "created_at": "2023-11-13T23:49:15.552Z",
+    "villains": []
+  },
+  {
+    "id": 158,
+    "title": "The Furnace",
+    "type": "short story",
+    "handle": "the-furnace",
+    "originallyPublishedIn": "Weekly Reader (September 2005)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Partial short story"
+    ],
+    "year": 2005,
+    "created_at": "2023-11-13T23:49:15.688Z",
+    "villains": []
+  },
+  {
+    "id": 159,
+    "title": "The Things They Left Behind",
+    "type": "short story",
+    "handle": "the-things-they-left-behind",
+    "originallyPublishedIn": "Transgressions  (May 2005)",
+    "collectedIn": "Just After Sunset (2008)",
+    "notes": [
+      "Nominee, Bram Stoker Award, 2006[2]"
+    ],
+    "year": 2005,
+    "created_at": "2023-11-13T23:49:15.857Z",
+    "villains": []
+  },
+  {
+    "id": 160,
+    "title": "Memory",
+    "type": "short story",
+    "handle": "memory",
+    "originallyPublishedIn": "Tin House #28 (July 2006)",
+    "collectedIn": "Blaze (2007)",
+    "notes": [
+      "Incorporated into Duma Key (2008)"
+    ],
+    "year": 2006,
+    "created_at": "2023-11-13T23:49:15.972Z",
+    "villains": []
+  },
+  {
+    "id": 161,
+    "title": "Willa",
+    "type": "short story",
+    "handle": "willa",
+    "originallyPublishedIn": "Playboy (December 2006)",
+    "collectedIn": "Just After Sunset (2008)",
+    "notes": [],
+    "year": 2006,
+    "created_at": "2023-11-13T23:49:16.097Z",
+    "villains": []
+  },
+  {
+    "id": 162,
+    "title": "Graduation Afternoon",
+    "type": "short story",
+    "handle": "graduation-afternoon",
+    "originallyPublishedIn": "Postscripts (March 2007)",
+    "collectedIn": "Just After Sunset (2008)",
+    "notes": [
+      "Nominee, Locus Award, 2008[2]"
+    ],
+    "year": 2007,
+    "created_at": "2023-11-13T23:49:16.253Z",
+    "villains": []
+  },
+  {
+    "id": 163,
+    "title": "The Gingerbread Girl",
+    "type": "novella",
+    "handle": "the-gingerbread-girl",
+    "originallyPublishedIn": "Esquire (July 2007)",
+    "collectedIn": "Just After Sunset (2008)",
+    "notes": [],
+    "year": 2007,
+    "created_at": "2023-11-13T23:49:16.379Z",
+    "villains": []
+  },
+  {
+    "id": 164,
+    "title": "Ayana",
+    "type": "short story",
+    "handle": "ayana",
+    "originallyPublishedIn": "The Paris Review (Fall 2007)",
+    "collectedIn": "Just After Sunset (2008)",
+    "notes": [],
+    "year": 2007,
+    "created_at": "2023-11-13T23:49:16.500Z",
+    "villains": []
+  },
+  {
+    "id": 165,
+    "title": "Mute",
+    "type": "short story",
+    "handle": "mute",
+    "originallyPublishedIn": "Playboy (December 2007)",
+    "collectedIn": "Just After Sunset (2008)",
+    "notes": [],
+    "year": 2007,
+    "created_at": "2023-11-13T23:49:16.620Z",
+    "villains": []
+  },
+  {
+    "id": 166,
+    "title": "A Very Tight Place",
+    "type": "novella",
+    "handle": "a-very-tight-place",
+    "originallyPublishedIn": "McSweeney's #27 (Spring 2008)",
+    "collectedIn": "Just After Sunset (2008)",
+    "notes": [],
+    "year": 2008,
+    "created_at": "2023-11-13T23:49:16.739Z",
+    "villains": []
+  },
+  {
+    "id": 167,
+    "title": "The New York Times at Special Bargain Rates",
+    "type": "short story",
+    "handle": "the-new-york-times-at-special-bargain-rates",
+    "originallyPublishedIn": "The Magazine of Fantasy & Science Fiction (October/November 2008)",
+    "collectedIn": "Just After Sunset (2008)",
+    "notes": [],
+    "year": 2008,
+    "created_at": "2023-11-13T23:49:16.857Z",
+    "villains": []
+  },
+  {
+    "id": 168,
+    "title": "N.",
+    "type": "novella",
+    "handle": "n-",
+    "originallyPublishedIn": "Just After Sunset (November 2008)",
+    "collectedIn": "Just After Sunset (2008)",
+    "notes": [
+      "Nominee, British Fantasy Award, 2009[2]"
+    ],
+    "year": 2008,
+    "created_at": "2023-11-13T23:49:16.973Z",
+    "villains": []
+  },
+  {
+    "id": 169,
+    "title": "Throttle",
+    "type": "novella",
+    "handle": "throttle",
+    "originallyPublishedIn": "He Is Legend (February 1, 2009)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "In collaboration with Joe Hill, part of Hill's collection Full Throttle"
+    ],
+    "year": 2009,
+    "created_at": "2023-11-13T23:49:17.087Z",
+    "villains": []
+  },
+  {
+    "id": 170,
+    "title": "Ur",
+    "type": "novella",
+    "handle": "ur",
+    "originallyPublishedIn": "Ur (February 12, 2009)",
+    "collectedIn": "The Bazaar of Bad Dreams (2015)",
+    "notes": [
+      "Originally published as an ebook",
+      " collected heavily revised"
+    ],
+    "year": 2009,
+    "created_at": "2023-11-13T23:49:17.203Z",
+    "villains": []
+  },
+  {
+    "id": 171,
+    "title": "Morality",
+    "type": "novella",
+    "handle": "morality",
+    "originallyPublishedIn": "Esquire (July 2009)",
+    "collectedIn": "The Bazaar of Bad Dreams (2015)",
+    "notes": [
+      "Previously included with the trade edition of Blockade Billy (2010)",
+      "Winner, Shirley Jackson Award, 2009[2]"
+    ],
+    "year": 2009,
+    "created_at": "2023-11-13T23:49:17.317Z",
+    "villains": []
+  },
+  {
+    "id": 172,
+    "title": "Mostly Old Men",
+    "type": "poem",
+    "handle": "mostly-old-men",
+    "originallyPublishedIn": "Tin House #40 (August 2009)",
+    "collectedIn": "Uncollected",
+    "notes": [],
+    "year": 2009,
+    "created_at": "2023-11-13T23:49:17.430Z",
+    "villains": []
+  },
+  {
+    "id": 174,
+    "title": "Premium Harmony",
+    "type": "short story",
+    "handle": "premium-harmony",
+    "originallyPublishedIn": "The New Yorker (November 9, 2009)",
+    "collectedIn": "The Bazaar of Bad Dreams (2015)",
+    "notes": [],
+    "year": 2009,
+    "created_at": "2023-11-13T23:49:17.688Z",
+    "villains": []
+  },
+  {
+    "id": 175,
+    "title": "Tommy",
+    "type": "poem",
+    "handle": "tommy",
+    "originallyPublishedIn": "Playboy (March 2010)",
+    "collectedIn": "The Bazaar of Bad Dreams (2015)",
+    "notes": [],
+    "year": 2010,
+    "created_at": "2023-11-13T23:49:17.810Z",
+    "villains": []
+  },
+  {
+    "id": 176,
+    "title": "Blockade Billy",
+    "type": "novella",
+    "handle": "blockade-billy",
+    "originallyPublishedIn": "Blockade Billy (April 2010)",
+    "collectedIn": "The Bazaar of Bad Dreams (2015)",
+    "notes": [],
+    "year": 2010,
+    "created_at": "2023-11-13T23:49:17.926Z",
+    "villains": []
+  },
+  {
+    "id": 177,
+    "title": "1922",
+    "type": "novella",
+    "handle": "1922",
+    "originallyPublishedIn": "Full Dark, No Stars (November 2010)",
+    "collectedIn": "Full Dark, No Stars (2010)",
+    "notes": [
+      "Nominee, British Fantasy Award, 2011[2]"
+    ],
+    "year": 2010,
+    "created_at": "2023-11-13T23:49:18.040Z",
+    "villains": [
+      {
+        "name": "Henry James",
+        "url": "https://stephen-king-api.onrender.com/api/villain/58"
+      },
+      {
+        "name": "Wilfred James",
+        "url": "https://stephen-king-api.onrender.com/api/villain/59"
+      }
+    ]
+  },
+  {
+    "id": 178,
+    "title": "Big Driver",
+    "type": "novella",
+    "handle": "big-driver",
+    "originallyPublishedIn": "Full Dark, No Stars (November 2010)",
+    "collectedIn": "Full Dark, No Stars (2010)",
+    "notes": [],
+    "year": 2010,
+    "created_at": "2023-11-13T23:49:18.283Z",
+    "villains": []
+  },
+  {
+    "id": 179,
+    "title": "Fair Extension",
+    "type": "novella",
+    "handle": "fair-extension",
+    "originallyPublishedIn": "Full Dark, No Stars (November 2010)",
+    "collectedIn": "Full Dark, No Stars (2010)",
+    "notes": [],
+    "year": 2010,
+    "created_at": "2023-11-13T23:49:18.398Z",
+    "villains": []
+  },
+  {
+    "id": 180,
+    "title": "A Good Marriage",
+    "type": "novella",
+    "handle": "a-good-marriage",
+    "originallyPublishedIn": "Full Dark, No Stars (November 2010)",
+    "collectedIn": "Full Dark, No Stars (2010)",
+    "notes": [],
+    "year": 2010,
+    "created_at": "2023-11-13T23:49:18.513Z",
+    "villains": [
+      {
+        "name": "Bob Anderson",
+        "url": "https://stephen-king-api.onrender.com/api/villain/1"
+      }
+    ]
+  },
+  {
+    "id": 181,
+    "title": "Herman Wouk Is Still Alive",
+    "type": "short story",
+    "handle": "herman-wouk-is-still-alive",
+    "originallyPublishedIn": "The Atlantic (May 2011)",
+    "collectedIn": "The Bazaar of Bad Dreams (2015)",
+    "notes": [
+      "Winner, Bram Stoker Award, 2012[2]"
+    ],
+    "year": 2011,
+    "created_at": "2023-11-13T23:49:18.630Z",
+    "villains": []
+  },
+  {
+    "id": 182,
+    "title": "Under the Weather",
+    "type": "short story",
+    "handle": "under-the-weather",
+    "originallyPublishedIn": "Paperback edition of Full Dark, No Stars (May 2011)",
+    "collectedIn": "The Bazaar of Bad Dreams (2015)",
+    "notes": [],
+    "year": 2011,
+    "created_at": "2023-11-13T23:49:18.744Z",
+    "villains": []
+  },
+  {
+    "id": 183,
+    "title": "Mile 81",
+    "type": "novella",
+    "handle": "mile-81",
+    "originallyPublishedIn": "Mile 81 (September 1, 2011)",
+    "collectedIn": "The Bazaar of Bad Dreams (2015)",
+    "notes": [
+      "Originally published as an ebook"
+    ],
+    "year": 2011,
+    "created_at": "2023-11-13T23:49:18.862Z",
+    "villains": []
+  },
+  {
+    "id": 184,
+    "title": "The Little Green God of Agony",
+    "type": "short story",
+    "handle": "the-little-green-god-of-agony",
+    "originallyPublishedIn": "A Book of Horrors (September 29, 2011)",
+    "collectedIn": "The Bazaar of Bad Dreams (2015)",
+    "notes": [
+      "Adapted into a webcomic",
+      "[3]Nominee, Locus Award, 2012[2]"
+    ],
+    "year": 2011,
+    "created_at": "2023-11-13T23:49:18.978Z",
+    "villains": []
+  },
+  {
+    "id": 185,
+    "title": "The Dune",
+    "type": "short story",
+    "handle": "the-dune",
+    "originallyPublishedIn": "Granta #117 (Fall 2011)",
+    "collectedIn": "The Bazaar of Bad Dreams (2015)",
+    "notes": [],
+    "year": 2011,
+    "created_at": "2023-11-13T23:49:19.102Z",
+    "villains": []
+  },
+  {
+    "id": 186,
+    "title": "In the Tall Grass",
+    "type": "novella",
+    "handle": "in-the-tall-grass",
+    "originallyPublishedIn": "Esquire (June/July–August 2012)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "In collaboration with Joe Hill, part of Hill's collection Full Throttle"
+    ],
+    "year": 2012,
+    "created_at": "2023-11-13T23:49:19.212Z",
+    "villains": [
+      {
+        "name": "Ross Humboldt",
+        "url": "https://stephen-king-api.onrender.com/api/villain/56"
+      }
+    ]
+  },
+  {
+    "id": 187,
+    "title": "A Face in the Crowd",
+    "type": "novella",
+    "handle": "a-face-in-the-crowd",
+    "originallyPublishedIn": "A Face in the Crowd (August 21, 2012)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Originally published as an ebook",
+      " in collaboration with Stewart O'Nan"
+    ],
+    "year": 2012,
+    "created_at": "2023-11-13T23:49:19.329Z",
+    "villains": []
+  },
+  {
+    "id": 188,
+    "title": "Batman and Robin Have an Altercation",
+    "type": "short story",
+    "handle": "batman-and-robin-have-an-altercation",
+    "originallyPublishedIn": "Harper's Magazine (September 2012)",
+    "collectedIn": "The Bazaar of Bad Dreams (2015)",
+    "notes": [],
+    "year": 2012,
+    "created_at": "2023-11-13T23:49:19.448Z",
+    "villains": []
+  },
+  {
+    "id": 189,
+    "title": "Afterlife",
+    "type": "short story",
+    "handle": "afterlife",
+    "originallyPublishedIn": "Tin House #56 (June 2013)",
+    "collectedIn": "The Bazaar of Bad Dreams (2015)",
+    "notes": [],
+    "year": 2013,
+    "created_at": "2023-11-13T23:49:19.570Z",
+    "villains": []
+  },
+  {
+    "id": 190,
+    "title": "The Rock and Roll Dead Zone",
+    "type": "short story",
+    "handle": "the-rock-and-roll-dead-zone",
+    "originallyPublishedIn": "Hard Listening (June 18, 2013)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Originally published as an ebook"
+    ],
+    "year": 2013,
+    "created_at": "2023-11-13T23:49:19.692Z",
+    "villains": []
+  },
+  {
+    "id": 191,
+    "title": "Summer Thunder",
+    "type": "short story",
+    "handle": "summer-thunder",
+    "originallyPublishedIn": "Turn Down the Lights (December 2013)",
+    "collectedIn": "The Bazaar of Bad Dreams (2015)",
+    "notes": [],
+    "year": 2013,
+    "created_at": "2023-11-13T23:49:19.805Z",
+    "villains": []
+  },
+  {
+    "id": 192,
+    "title": "Bad Little Kid",
+    "type": "short story",
+    "handle": "bad-little-kid",
+    "originallyPublishedIn": "Bad Little Kid (March 14, 2014)",
+    "collectedIn": "The Bazaar of Bad Dreams (2015)",
+    "notes": [
+      "Originally published as an ebook in French and German languages only"
+    ],
+    "year": 2014,
+    "created_at": "2023-11-13T23:49:19.926Z",
+    "villains": []
+  },
+  {
+    "id": 193,
+    "title": "That Bus Is Another World",
+    "type": "short story",
+    "handle": "that-bus-is-another-world",
+    "originallyPublishedIn": "Esquire (August 2014)",
+    "collectedIn": "The Bazaar of Bad Dreams (2015)",
+    "notes": [],
+    "year": 2014,
+    "created_at": "2023-11-13T23:49:20.046Z",
+    "villains": []
+  },
+  {
+    "id": 194,
+    "title": "A Death",
+    "type": "short story",
+    "handle": "a-death",
+    "originallyPublishedIn": "The New Yorker (March 9, 2015)",
+    "collectedIn": "The Bazaar of Bad Dreams (2015)",
+    "notes": [],
+    "year": 2015,
+    "created_at": "2023-11-13T23:49:20.166Z",
+    "villains": []
+  },
+  {
+    "id": 195,
+    "title": "Drunken Fireworks",
+    "type": "short story",
+    "handle": "drunken-fireworks",
+    "originallyPublishedIn": "Drunken Fireworks (June 30, 2015)",
+    "collectedIn": "The Bazaar of Bad Dreams (2015)",
+    "notes": [
+      "Originally published as an audiobook"
+    ],
+    "year": 2015,
+    "created_at": "2023-11-13T23:49:20.279Z",
+    "villains": []
+  },
+  {
+    "id": 196,
+    "title": "Mister Yummy",
+    "type": "short story",
+    "handle": "mister-yummy",
+    "originallyPublishedIn": "The Bazaar of Bad Dreams (November 2015)",
+    "collectedIn": "The Bazaar of Bad Dreams (2015)",
+    "notes": [],
+    "year": 2015,
+    "created_at": "2023-11-13T23:49:20.398Z",
+    "villains": []
+  },
+  {
+    "id": 197,
+    "title": "Obits",
+    "type": "short story",
+    "handle": "obits",
+    "originallyPublishedIn": "The Bazaar of Bad Dreams (November 2015)",
+    "collectedIn": "The Bazaar of Bad Dreams (2015)",
+    "notes": [
+      "Nominee, Hugo Award, 2016[2]"
+    ],
+    "year": 2015,
+    "created_at": "2023-11-13T23:49:20.519Z",
+    "villains": []
+  },
+  {
+    "id": 198,
+    "title": "Cookie Jar",
+    "type": "short story",
+    "handle": "cookie-jar",
+    "originallyPublishedIn": "Virginia Quarterly Review (Spring 2016)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Appears in the paperback edition of The Bazaar of Bad Dreams (2016)"
+    ],
+    "year": 2016,
+    "created_at": "2023-11-13T23:49:20.635Z",
+    "villains": []
+  },
+  {
+    "id": 199,
+    "title": "The Music Room",
+    "type": "short story",
+    "handle": "the-music-room",
+    "originallyPublishedIn": "Playboy (December 2016)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Included with audio readings of Gwendy's Button Box"
+    ],
+    "year": 2016,
+    "created_at": "2023-11-13T23:49:20.745Z",
+    "villains": []
+  },
+  {
+    "id": 200,
+    "title": "Gwendy's Button Box",
+    "type": "novella",
+    "handle": "gwendy-s-button-box",
+    "originallyPublishedIn": "Gwendy's Button Box (May 2017)",
+    "collectedIn": "Uncollected (standalone book)",
+    "notes": [
+      "written with Richard Chizmar"
+    ],
+    "year": 2017,
+    "created_at": "2023-11-13T23:49:20.861Z",
+    "villains": []
+  },
+  {
+    "id": 201,
+    "title": "Thin Scenery",
+    "type": "play",
+    "handle": "thin-scenery",
+    "originallyPublishedIn": "Ploughshares (Summer 2017)",
+    "collectedIn": "Uncollected",
+    "notes": [],
+    "year": 2017,
+    "created_at": "2023-11-13T23:49:20.979Z",
+    "villains": []
+  },
+  {
+    "id": 202,
+    "title": "Laurie",
+    "type": "short story",
+    "handle": "laurie",
+    "originallyPublishedIn": "stephenking.com (May 17, 2018)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "Free download",
+      "[4] included in the Elevation audiobook"
+    ],
+    "year": 2018,
+    "created_at": "2023-11-13T23:49:21.100Z",
+    "villains": []
+  },
+  {
+    "id": 203,
+    "title": "Elevation",
+    "type": "novella",
+    "handle": "elevation",
+    "originallyPublishedIn": "Elevation (October 2018)",
+    "collectedIn": "Uncollected (standalone book)",
+    "notes": [],
+    "year": 2018,
+    "created_at": "2023-11-13T23:49:21.223Z",
+    "villains": []
+  },
+  {
+    "id": 204,
+    "title": "The Turbulence Expert",
+    "type": "short story",
+    "handle": "the-turbulence-expert",
+    "originallyPublishedIn": "Flight or Fright (September 4, 2018)",
+    "collectedIn": "Uncollected",
+    "notes": [],
+    "year": 2018,
+    "created_at": "2023-11-13T23:49:21.341Z",
+    "villains": []
+  },
+  {
+    "id": 205,
+    "title": "Squad D",
+    "type": "short story",
+    "handle": "squad-d",
+    "originallyPublishedIn": "Shivers VIII  (April 18, 2019)",
+    "collectedIn": "Uncollected",
+    "notes": [
+      "written in the late 1970s"
+    ],
+    "year": 2019,
+    "created_at": "2023-11-13T23:49:21.458Z",
+    "villains": []
+  },
+  {
+    "id": 206,
+    "title": "The Fifth Step",
+    "type": "short story",
+    "handle": "the-fifth-step",
+    "originallyPublishedIn": "Harper's Magazine (March 2020)",
+    "collectedIn": "Uncollected",
+    "notes": [],
+    "year": 2020,
+    "created_at": "2023-11-13T23:49:21.582Z",
+    "villains": []
+  },
+  {
+    "id": 207,
+    "title": "If It Bleeds",
+    "type": "novella",
+    "handle": "if-it-bleeds",
+    "originallyPublishedIn": "If It Bleeds (April 2020)",
+    "collectedIn": "If It Bleeds (2020)",
+    "notes": [
+      "First novella in the Holly Gibney Series"
+    ],
+    "year": 2020,
+    "created_at": "2023-11-13T23:49:21.695Z",
+    "villains": []
+  },
+  {
+    "id": 208,
+    "title": "The Life of Chuck",
+    "type": "novella",
+    "handle": "the-life-of-chuck",
+    "originallyPublishedIn": "If It Bleeds (April 2020)",
+    "collectedIn": "If It Bleeds (2020)",
+    "notes": [],
+    "year": 2020,
+    "created_at": "2023-11-13T23:49:21.816Z",
+    "villains": []
+  },
+  {
+    "id": 209,
+    "title": "Mr. Harrigan's Phone",
+    "type": "novella",
+    "handle": "mr-harrigan-s-phone",
+    "originallyPublishedIn": "If It Bleeds (April 2020)",
+    "collectedIn": "If It Bleeds (2020)",
+    "notes": [],
+    "year": 2020,
+    "created_at": "2023-11-13T23:49:21.928Z",
+    "villains": []
+  },
+  {
+    "id": 210,
+    "title": "Rat",
+    "type": "novella",
+    "handle": "rat",
+    "originallyPublishedIn": "If It Bleeds (April 2020)",
+    "collectedIn": "If It Bleeds (2020)",
+    "notes": [],
+    "year": 2020,
+    "created_at": "2023-11-13T23:49:22.042Z",
+    "villains": []
+  },
+  {
+    "id": 211,
+    "title": "On Slide Inn Road",
+    "type": "short story",
+    "handle": "on-slide-inn-road",
+    "originallyPublishedIn": "Esquire Magazine (October/November 2020)",
+    "collectedIn": "Uncollected",
+    "notes": [],
+    "year": 2020,
+    "created_at": "2023-11-13T23:49:22.160Z",
+    "villains": []
+  },
+  {
+    "id": 212,
+    "title": "Willie the Weirdo",
+    "type": "short story",
+    "handle": "willie-the-weirdo",
+    "originallyPublishedIn": "McSweeney's 65 (September 2021)",
+    "collectedIn": "Uncollected",
+    "notes": [],
+    "year": 2021,
+    "created_at": "2023-11-13T23:49:22.279Z",
+    "villains": []
+  }
+]

--- a/src/app/data/villains.json
+++ b/src/app/data/villains.json
@@ -1,0 +1,2772 @@
+[
+  {
+    "id": 1,
+    "name": "Bob Anderson",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Pownal residents",
+      "Yarmouth residents",
+      "Residents of Maine",
+      "Villains",
+      "Crime"
+    ],
+    "created_at": "2023-11-13T23:49:22.390Z",
+    "books": [],
+    "shorts": [
+      {
+        "title": "A Good Marriage",
+        "url": "https://stephen-king-api.onrender.com/api/book/180"
+      }
+    ]
+  },
+  {
+    "id": 2,
+    "name": "Kurt Barlow",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 2,
+    "notes": [
+      "Characters",
+      "Jerusalem's Lot residents",
+      "Residents of Maine",
+      "Villains",
+      "Antagonists"
+    ],
+    "created_at": "2023-11-13T23:49:22.625Z",
+    "books": [
+      {
+        "title": "Salem's Lot",
+        "url": "https://stephen-king-api.onrender.com/api/book/2"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 3,
+    "name": "Blaine the Mono",
+    "gender": null,
+    "status": "Deceased",
+    "types_id": 6,
+    "notes": [
+      "Characters",
+      "Unsourced quotes",
+      "The Dark Tower",
+      "Villains",
+      "Machines",
+      "Antagonists"
+    ],
+    "created_at": "2023-11-13T23:49:22.743Z",
+    "books": [
+      {
+        "title": "The Dark Tower IV: Wizard and Glass",
+        "url": "https://stephen-king-api.onrender.com/api/book/34"
+      },
+      {
+        "title": "The Dark Tower III: The Waste Lands",
+        "url": "https://stephen-king-api.onrender.com/api/book/25"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 4,
+    "name": "Tina Blake",
+    "gender": "Female",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Ewen High School students",
+      "Residents of Maine",
+      "Chamberlain residents",
+      "Bullies",
+      "Name-continuity",
+      "Lovers",
+      "Bate High School students",
+      "Villains",
+      "Antagonists",
+      "Carrie"
+    ],
+    "created_at": "2023-11-13T23:49:22.968Z",
+    "books": [
+      {
+        "title": "Carrie",
+        "url": "https://stephen-king-api.onrender.com/api/book/1"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 5,
+    "name": "Malachai Boardman",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Villains",
+      "Antagonists"
+    ],
+    "created_at": "2023-11-13T23:49:23.089Z",
+    "books": [],
+    "shorts": [
+      {
+        "title": "Children of the Corn",
+        "url": "https://stephen-king-api.onrender.com/api/book/53"
+      }
+    ]
+  },
+  {
+    "id": 6,
+    "name": "James Boon",
+    "gender": "Male",
+    "status": "Alive",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Villains",
+      "Jerusalem's Lot residents"
+    ],
+    "created_at": "2023-11-13T23:49:23.203Z",
+    "books": [],
+    "shorts": [
+      {
+        "title": "Jerusalem's Lot",
+        "url": "https://stephen-king-api.onrender.com/api/book/58"
+      }
+    ]
+  },
+  {
+    "id": 7,
+    "name": "Henry Bowers",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Unsourced quotes",
+      "Bullies",
+      "Characters with mental illness",
+      "Derry residents",
+      "IT",
+      "Residents of Maine",
+      "Seekers of vengeance",
+      "Villains",
+      "Leaders",
+      "Gang Leaders",
+      "Slashers",
+      "Victims",
+      "LGBT",
+      "Antagonists"
+    ],
+    "created_at": "2023-11-13T23:49:23.320Z",
+    "books": [
+      {
+        "title": "It",
+        "url": "https://stephen-king-api.onrender.com/api/book/19"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 8,
+    "name": "Butch Bowers",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Unsourced quotes",
+      "Derry residents",
+      "Residents of Maine",
+      "IT",
+      "Antagonists",
+      "Villains",
+      "Bullies",
+      "Characters with mental illness",
+      "Spouses"
+    ],
+    "created_at": "2023-11-13T23:49:23.438Z",
+    "books": [
+      {
+        "title": "It",
+        "url": "https://stephen-king-api.onrender.com/api/book/19"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 9,
+    "name": "Greta Bowie",
+    "gender": "Female",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Derry residents",
+      "IT",
+      "Residents of Maine",
+      "Bullies",
+      "Leaders",
+      "Antagonists",
+      "Status dependant on version",
+      "Villains"
+    ],
+    "created_at": "2023-11-13T23:49:23.561Z",
+    "books": [
+      {
+        "title": "It",
+        "url": "https://stephen-king-api.onrender.com/api/book/19"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 10,
+    "name": "Marten Broadcloak",
+    "gender": "Male",
+    "status": "Alive",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Gilead residents",
+      "The Dark Tower",
+      "Residents of All-world",
+      "Villains",
+      "Lovers",
+      "Multiverse"
+    ],
+    "created_at": "2023-11-13T23:49:23.690Z",
+    "books": [
+      {
+        "title": "The Dark Tower: The Gunslinger",
+        "url": "https://stephen-king-api.onrender.com/api/book/12"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 11,
+    "name": "Christine (car)",
+    "gender": "Female",
+    "status": "Alive",
+    "types_id": 6,
+    "notes": [
+      "Characters",
+      "Objects",
+      "Villains",
+      "Christine",
+      "Demonic items",
+      "Antagonists",
+      "Ghosts",
+      "Murderers",
+      "Seekers of vengeance"
+    ],
+    "created_at": "2023-11-13T23:49:23.805Z",
+    "books": [
+      {
+        "title": "Christine",
+        "url": "https://stephen-king-api.onrender.com/api/book/13"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 12,
+    "name": "Isaac Chroner",
+    "gender": null,
+    "status": "Deceased",
+    "types_id": 6,
+    "notes": [
+      "Characters",
+      "Villains",
+      "Antagonists"
+    ],
+    "created_at": "2023-11-13T23:49:23.918Z",
+    "books": [],
+    "shorts": [
+      {
+        "title": "Children of the Corn",
+        "url": "https://stephen-king-api.onrender.com/api/book/53"
+      }
+    ]
+  },
+  {
+    "id": 13,
+    "name": "Winston Church",
+    "gender": null,
+    "status": "Deceased",
+    "types_id": 8,
+    "notes": [
+      "Characters",
+      "Cats",
+      "Villains",
+      "Pet Sematary",
+      "Status dependant on version",
+      "Revived"
+    ],
+    "created_at": "2023-11-13T23:49:24.039Z",
+    "books": [
+      {
+        "title": "Pet Sematary",
+        "url": "https://stephen-king-api.onrender.com/api/book/14"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 14,
+    "name": "Cindi",
+    "gender": "Female",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Ewen High School students",
+      "Unknown fates",
+      "Chamberlain residents",
+      "Residents of Maine",
+      "Bate High School students",
+      "Bullies",
+      "Villains",
+      "Name-continuity",
+      "Antagonists",
+      "Victims",
+      "Carrie"
+    ],
+    "created_at": "2023-11-13T23:49:24.159Z",
+    "books": [
+      {
+        "title": "Carrie",
+        "url": "https://stephen-king-api.onrender.com/api/book/1"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 15,
+    "name": "Gage Creed",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 3,
+    "notes": [
+      "Characters",
+      "Villains",
+      "Pet Sematary",
+      "Status dependant on version",
+      "Revived",
+      "Antagonists",
+      "Residents of Maine"
+    ],
+    "created_at": "2023-11-13T23:49:24.285Z",
+    "books": [
+      {
+        "title": "Pet Sematary",
+        "url": "https://stephen-king-api.onrender.com/api/book/14"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 16,
+    "name": "Myra Crewes",
+    "gender": "Female",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Chamberlain residents",
+      "Residents of Maine",
+      "Villains",
+      "Bullies",
+      "Ewen High School students",
+      "Unknown fates",
+      "Bate High School students",
+      "Antagonists",
+      "Victims",
+      "Carrie"
+    ],
+    "created_at": "2023-11-13T23:49:24.403Z",
+    "books": [
+      {
+        "title": "Carrie",
+        "url": "https://stephen-king-api.onrender.com/api/book/1"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 17,
+    "name": "Crimson King",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 3,
+    "notes": [
+      "Characters",
+      "The Dark Tower",
+      "Multiverse",
+      "Villains",
+      "Antagonists"
+    ],
+    "created_at": "2023-11-13T23:49:24.525Z",
+    "books": [
+      {
+        "title": "Insomnia",
+        "url": "https://stephen-king-api.onrender.com/api/book/29"
+      },
+      {
+        "title": "The Dark Tower: The Gunslinger",
+        "url": "https://stephen-king-api.onrender.com/api/book/12"
+      },
+      {
+        "title": "Black House",
+        "url": "https://stephen-king-api.onrender.com/api/book/38"
+      },
+      {
+        "title": "The Dark Tower VII: The Dark Tower",
+        "url": "https://stephen-king-api.onrender.com/api/book/42"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 18,
+    "name": "Victor Criss",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Unsourced quotes",
+      "Bullies",
+      "Derry residents",
+      "Residents of Maine",
+      "IT",
+      "Villains",
+      "Antagonists",
+      "Victims",
+      "Status dependant on version"
+    ],
+    "created_at": "2023-11-13T23:49:24.664Z",
+    "books": [
+      {
+        "title": "It",
+        "url": "https://stephen-king-api.onrender.com/api/book/19"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 19,
+    "name": "Cujo",
+    "gender": null,
+    "status": "Deceased",
+    "types_id": 8,
+    "notes": [
+      "Characters",
+      "Dogs",
+      "Characters with mental illness",
+      "Castle Rock residents",
+      "Residents of Maine",
+      "Villains",
+      "Antagonists"
+    ],
+    "created_at": "2023-11-13T23:49:24.799Z",
+    "books": [
+      {
+        "title": "Cujo",
+        "url": "https://stephen-king-api.onrender.com/api/book/10"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 20,
+    "name": "Arnie Cunningham",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Unsourced quotes",
+      "Seekers of vengeance",
+      "Lovers",
+      "Christine",
+      "Villains",
+      "Antagonists",
+      "Victims",
+      "Heroes",
+      "Protagonists"
+    ],
+    "created_at": "2023-11-13T23:49:24.927Z",
+    "books": [
+      {
+        "title": "Christine",
+        "url": "https://stephen-king-api.onrender.com/api/book/13"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 21,
+    "name": "Dandelo",
+    "gender": "Male",
+    "status": "Alive",
+    "types_id": 2,
+    "notes": [
+      "Characters",
+      "Villains"
+    ],
+    "created_at": "2023-11-13T23:49:25.057Z",
+    "books": [
+      {
+        "title": "The Dark Tower VII: The Dark Tower",
+        "url": "https://stephen-king-api.onrender.com/api/book/42"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 22,
+    "name": "Norman Daniels",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Unsourced quotes",
+      "Police",
+      "Antagonists",
+      "Villains",
+      "Murderers"
+    ],
+    "created_at": "2023-11-13T23:49:25.174Z",
+    "books": [
+      {
+        "title": "Rose Madder",
+        "url": "https://stephen-king-api.onrender.com/api/book/30"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 23,
+    "name": "Susan Day",
+    "gender": "Female",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Villains"
+    ],
+    "created_at": "2023-11-13T23:49:25.311Z",
+    "books": [
+      {
+        "title": "Rose Madder",
+        "url": "https://stephen-king-api.onrender.com/api/book/30"
+      },
+      {
+        "title": "Insomnia",
+        "url": "https://stephen-king-api.onrender.com/api/book/29"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 24,
+    "name": "Cordelia Delgado",
+    "gender": "Female",
+    "status": "Alive",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Villains",
+      "The Dark Tower",
+      "Antagonists"
+    ],
+    "created_at": "2023-11-13T23:49:25.430Z",
+    "books": [
+      {
+        "title": "The Dark Tower IV: Wizard and Glass",
+        "url": "https://stephen-king-api.onrender.com/api/book/34"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 25,
+    "name": "Billy deLois",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Chamberlain residents",
+      "Residents of Maine",
+      "Unknown fates",
+      "Ewen High School students",
+      "Bullies",
+      "Villains",
+      "Antagonists",
+      "Carrie"
+    ],
+    "created_at": "2023-11-13T23:49:25.546Z",
+    "books": [
+      {
+        "title": "Carrie",
+        "url": "https://stephen-king-api.onrender.com/api/book/1"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 26,
+    "name": "Horace M. Derwent",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 7,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Appearances",
+      "The Shining",
+      "Villains",
+      "Ghosts",
+      "LGBT"
+    ],
+    "created_at": "2023-11-13T23:49:25.758Z",
+    "books": [
+      {
+        "title": "The Shining",
+        "url": "https://stephen-king-api.onrender.com/api/book/3"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 27,
+    "name": "Mordred Deschain",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 3,
+    "notes": [
+      "Characters",
+      "ESPers",
+      "The Dark Tower",
+      "Multiverse",
+      "Villains",
+      "Antagonists"
+    ],
+    "created_at": "2023-11-13T23:49:25.873Z",
+    "books": [
+      {
+        "title": "The Dark Tower VII: The Dark Tower",
+        "url": "https://stephen-king-api.onrender.com/api/book/42"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 28,
+    "name": "Bogs Diamond",
+    "gender": "Male",
+    "status": "Alive",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Villains",
+      "Leaders"
+    ],
+    "created_at": "2023-11-13T23:49:25.992Z",
+    "books": [],
+    "shorts": [
+      {
+        "title": "Rita Hayworth and Shawshank Redemption",
+        "url": "https://stephen-king-api.onrender.com/api/book/86"
+      }
+    ]
+  },
+  {
+    "id": 29,
+    "name": "Frank Dodd",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Police",
+      "Murderers",
+      "Villains",
+      "Government employees",
+      "Characters with mental illness",
+      "The Dead Zone",
+      "Antagonists"
+    ],
+    "created_at": "2023-11-13T23:49:26.115Z",
+    "books": [
+      {
+        "title": "The Dead Zone",
+        "url": "https://stephen-king-api.onrender.com/api/book/7"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 30,
+    "name": "Henrietta Dodd",
+    "gender": "Female",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "The Dead Zone",
+      "Villains"
+    ],
+    "created_at": "2023-11-13T23:49:26.240Z",
+    "books": [
+      {
+        "title": "The Dead Zone",
+        "url": "https://stephen-king-api.onrender.com/api/book/7"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 31,
+    "name": "Rose the Hat",
+    "gender": "Female",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Doctor Sleep",
+      "Villains",
+      "Harassers",
+      "Murderers",
+      "LGBT",
+      "Bullies"
+    ],
+    "created_at": "2023-11-13T23:49:26.355Z",
+    "books": [
+      {
+        "title": "Doctor Sleep",
+        "url": "https://stephen-king-api.onrender.com/api/book/52"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 32,
+    "name": "Rhea Dubativo",
+    "gender": "Female",
+    "status": "Alive",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Hambry residents",
+      "The Dark Tower",
+      "Residents of All-world",
+      "Villains",
+      "Antagonists"
+    ],
+    "created_at": "2023-11-13T23:49:26.474Z",
+    "books": [
+      {
+        "title": "The Dark Tower IV: Wizard and Glass",
+        "url": "https://stephen-king-api.onrender.com/api/book/34"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 33,
+    "name": "Kurt Dussander",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Villains"
+    ],
+    "created_at": "2023-11-13T23:49:26.598Z",
+    "books": [],
+    "shorts": [
+      {
+        "title": "Apt Pupil",
+        "url": "https://stephen-king-api.onrender.com/api/book/83"
+      }
+    ]
+  },
+  {
+    "id": 34,
+    "name": "Donald Merwin Elbert",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Villains",
+      "Antagonists",
+      "The Stand",
+      "Characters with mental illness"
+    ],
+    "created_at": "2023-11-13T23:49:26.707Z",
+    "books": [
+      {
+        "title": "The Stand",
+        "url": "https://stephen-king-api.onrender.com/api/book/5"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 35,
+    "name": "Marcia Fadden",
+    "gender": "Female",
+    "status": "Alive",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Derry residents",
+      "IT",
+      "Residents of Maine",
+      "Villains",
+      "Bullies"
+    ],
+    "created_at": "2023-11-13T23:49:26.820Z",
+    "books": [
+      {
+        "title": "It",
+        "url": "https://stephen-king-api.onrender.com/api/book/19"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 36,
+    "name": "John Farson",
+    "gender": "Male",
+    "status": "Alive",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "The Dark Tower",
+      "Villains",
+      "Antagonists"
+    ],
+    "created_at": "2023-11-13T23:49:26.944Z",
+    "books": [
+      {
+        "title": "The Dark Tower IV: Wizard and Glass",
+        "url": "https://stephen-king-api.onrender.com/api/book/34"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 37,
+    "name": "Randall Flagg",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 3,
+    "notes": [
+      "Characters",
+      "The Stand",
+      "The Dark Tower",
+      "Villains",
+      "Bullies",
+      "Leaders",
+      "Revived",
+      "Antagonists",
+      "Meta-fiction",
+      "Dystopian"
+    ],
+    "created_at": "2023-11-13T23:49:27.063Z",
+    "books": [
+      {
+        "title": "The Stand",
+        "url": "https://stephen-king-api.onrender.com/api/book/5"
+      },
+      {
+        "title": "The Eyes of the Dragon",
+        "url": "https://stephen-king-api.onrender.com/api/book/17"
+      },
+      {
+        "title": "The Long Walk",
+        "url": "https://stephen-king-api.onrender.com/api/book/6"
+      },
+      {
+        "title": "The Dark Tower: The Gunslinger",
+        "url": "https://stephen-king-api.onrender.com/api/book/12"
+      },
+      {
+        "title": "The Dark Tower VII: The Dark Tower",
+        "url": "https://stephen-king-api.onrender.com/api/book/42"
+      },
+      {
+        "title": "The Dark Tower IV: Wizard and Glass",
+        "url": "https://stephen-king-api.onrender.com/api/book/34"
+      },
+      {
+        "title": "The Dark Tower III: The Waste Lands",
+        "url": "https://stephen-king-api.onrender.com/api/book/25"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 38,
+    "name": "Kenny Garson",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Ewen High School students",
+      "Chamberlain residents",
+      "Bullies",
+      "Residents of Maine",
+      "Villains",
+      "Victims",
+      "Bate High School students",
+      "Unknown fates",
+      "Antagonists",
+      "Carrie"
+    ],
+    "created_at": "2023-11-13T23:49:27.183Z",
+    "books": [
+      {
+        "title": "Carrie",
+        "url": "https://stephen-king-api.onrender.com/api/book/1"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 39,
+    "name": "John Garton",
+    "gender": "Male",
+    "status": "Alive",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Bullies",
+      "Derry residents",
+      "Residents of Maine",
+      "IT",
+      "Antagonists",
+      "Villains",
+      "Teachers"
+    ],
+    "created_at": "2023-11-13T23:49:27.301Z",
+    "books": [
+      {
+        "title": "It",
+        "url": "https://stephen-king-api.onrender.com/api/book/19"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 40,
+    "name": "Leland Gaunt",
+    "gender": "Male",
+    "status": "Alive",
+    "types_id": 6,
+    "notes": [
+      "Characters",
+      "Villains",
+      "Castle Rock residents",
+      "Antagonists"
+    ],
+    "created_at": "2023-11-13T23:49:27.414Z",
+    "books": [
+      {
+        "title": "Needful Things",
+        "url": "https://stephen-king-api.onrender.com/api/book/26"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 41,
+    "name": "Gerald Burlingame",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Antagonists",
+      "Spouses",
+      "Villains",
+      "Gerald's Game",
+      "Residents of Maine"
+    ],
+    "created_at": "2023-11-13T23:49:27.535Z",
+    "books": [
+      {
+        "title": "Gerald's Game",
+        "url": "https://stephen-king-api.onrender.com/api/book/27"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 42,
+    "name": "The Gladiators",
+    "gender": "Male",
+    "status": "Alive",
+    "types_id": 5,
+    "notes": [
+      "Characters",
+      "Villains"
+    ],
+    "created_at": "2023-11-13T23:49:27.646Z",
+    "books": [
+      {
+        "title": "The Running Man",
+        "url": "https://stephen-king-api.onrender.com/api/book/11"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 43,
+    "name": "Peter Gordon",
+    "gender": "Male",
+    "status": "Alive",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Derry residents",
+      "Residents of Maine",
+      "Bullies",
+      "Antagonists",
+      "Victims",
+      "IT",
+      "Villains"
+    ],
+    "created_at": "2023-11-13T23:49:27.764Z",
+    "books": [
+      {
+        "title": "It",
+        "url": "https://stephen-king-api.onrender.com/api/book/19"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 44,
+    "name": "Mary Lila Grace",
+    "gender": "Female",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Ewen High School students",
+      "Chamberlain residents",
+      "Bullies",
+      "Villains",
+      "Lovers",
+      "Carrie"
+    ],
+    "created_at": "2023-11-13T23:49:27.890Z",
+    "books": [
+      {
+        "title": "Carrie",
+        "url": "https://stephen-king-api.onrender.com/api/book/1"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 45,
+    "name": "Delbert Grady",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 7,
+    "notes": [
+      "Characters",
+      "Spouses",
+      "Lovers",
+      "Ghosts",
+      "The Shining",
+      "Villains",
+      "Harassers"
+    ],
+    "created_at": "2023-11-13T23:49:28.006Z",
+    "books": [
+      {
+        "title": "The Shining",
+        "url": "https://stephen-king-api.onrender.com/api/book/3"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 46,
+    "name": "Byron Hadley",
+    "gender": "Male",
+    "status": "Alive",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Villains",
+      "Government employees",
+      "Antagonists"
+    ],
+    "created_at": "2023-11-13T23:49:28.126Z",
+    "books": [],
+    "shorts": [
+      {
+        "title": "Rita Hayworth and Shawshank Redemption",
+        "url": "https://stephen-king-api.onrender.com/api/book/86"
+      }
+    ]
+  },
+  {
+    "id": 47,
+    "name": "John Halston",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Villains"
+    ],
+    "created_at": "2023-11-13T23:49:28.244Z",
+    "books": [],
+    "shorts": [
+      {
+        "title": "The Cat from Hell",
+        "url": "https://stephen-king-api.onrender.com/api/book/55"
+      }
+    ]
+  },
+  {
+    "id": 48,
+    "name": "Lane Hardy",
+    "gender": "Male",
+    "status": "Alive",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Villains",
+      "Antagonists"
+    ],
+    "created_at": "2023-11-13T23:49:28.357Z",
+    "books": [
+      {
+        "title": "Joyland",
+        "url": "https://stephen-king-api.onrender.com/api/book/51"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 49,
+    "name": "Christine Hargensen",
+    "gender": "Female",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Unsourced quotes",
+      "Chamberlain residents",
+      "Leaders",
+      "Bullies",
+      "Seekers of vengeance",
+      "Residents of Maine",
+      "Villains",
+      "Bate High School students",
+      "Ewen High School students",
+      "Lovers",
+      "Gang Leaders",
+      "Antagonists",
+      "Victims",
+      "Carrie"
+    ],
+    "created_at": "2023-11-13T23:49:28.475Z",
+    "books": [
+      {
+        "title": "Carrie",
+        "url": "https://stephen-king-api.onrender.com/api/book/1"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 50,
+    "name": "Brady Hartsfield",
+    "gender": "Male",
+    "status": "Alive",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Villains",
+      "Antagonists",
+      "Bill Hodges"
+    ],
+    "created_at": "2023-11-13T23:49:28.598Z",
+    "books": [
+      {
+        "title": "Mr. Mercedes",
+        "url": "https://stephen-king-api.onrender.com/api/book/53"
+      },
+      {
+        "title": "Finders Keepers",
+        "url": "https://stephen-king-api.onrender.com/api/book/55"
+      },
+      {
+        "title": "End of Watch",
+        "url": "https://stephen-king-api.onrender.com/api/book/56"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 51,
+    "name": "Lloyd Henreid",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Unsourced quotes",
+      "Villains",
+      "Crime",
+      "Antagonists",
+      "The Stand"
+    ],
+    "created_at": "2023-11-13T23:49:28.714Z",
+    "books": [
+      {
+        "title": "The Stand",
+        "url": "https://stephen-king-api.onrender.com/api/book/5"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 52,
+    "name": "Gladys Hickson",
+    "gender": "Female",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "The Institute",
+      "Villains",
+      "Bullies",
+      "Seekers of vengeance"
+    ],
+    "created_at": "2023-11-13T23:49:28.834Z",
+    "books": [
+      {
+        "title": "The Institute",
+        "url": "https://stephen-king-api.onrender.com/api/book/61"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 53,
+    "name": "Patrick Hockstetter",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Unsourced quotes",
+      "IT",
+      "Victims",
+      "Villains",
+      "Rapists",
+      "Derry residents",
+      "Residents of Maine",
+      "Bullies",
+      "LGBT",
+      "Antagonists",
+      "Derry",
+      "Characters with mental illness"
+    ],
+    "created_at": "2023-11-13T23:49:28.947Z",
+    "books": [
+      {
+        "title": "It",
+        "url": "https://stephen-king-api.onrender.com/api/book/19"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 54,
+    "name": "James Hollister",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Firestarter",
+      "Government employees",
+      "Villains"
+    ],
+    "created_at": "2023-11-13T23:49:29.074Z",
+    "books": [
+      {
+        "title": "Firestarter",
+        "url": "https://stephen-king-api.onrender.com/api/book/8"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 55,
+    "name": "Belch Huggins",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Bullies",
+      "Derry residents",
+      "Residents of Maine",
+      "IT",
+      "Antagonists",
+      "Victims",
+      "Villains",
+      "Status dependant on version"
+    ],
+    "created_at": "2023-11-13T23:49:29.191Z",
+    "books": [
+      {
+        "title": "It",
+        "url": "https://stephen-king-api.onrender.com/api/book/19"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 56,
+    "name": "Ross Humboldt",
+    "gender": "Male",
+    "status": "Alive",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Villains",
+      "In the Tall Grass",
+      "Alive"
+    ],
+    "created_at": "2023-11-13T23:49:29.310Z",
+    "books": [],
+    "shorts": [
+      {
+        "title": "In the Tall Grass",
+        "url": "https://stephen-king-api.onrender.com/api/book/186"
+      }
+    ]
+  },
+  {
+    "id": 57,
+    "name": "It (Creature)",
+    "gender": "Unknown",
+    "status": "Deceased",
+    "types_id": 4,
+    "notes": [
+      "Characters",
+      "Unsourced quotes",
+      "Seekers of vengeance",
+      "Brainwashers",
+      "IT",
+      "The Dark Tower",
+      "Derry residents",
+      "Residents of Maine",
+      "Antagonists",
+      "Villains"
+    ],
+    "created_at": "2023-11-13T23:49:29.429Z",
+    "books": [
+      {
+        "title": "It",
+        "url": "https://stephen-king-api.onrender.com/api/book/19"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 58,
+    "name": "Henry James",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Villains"
+    ],
+    "created_at": "2023-11-13T23:49:29.551Z",
+    "books": [],
+    "shorts": [
+      {
+        "title": "1922",
+        "url": "https://stephen-king-api.onrender.com/api/book/177"
+      }
+    ]
+  },
+  {
+    "id": 59,
+    "name": "Wilfred James",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Librarians",
+      "Spouses",
+      "Protagonists",
+      "Villains",
+      "Characters with mental illness"
+    ],
+    "created_at": "2023-11-13T23:49:29.665Z",
+    "books": [],
+    "shorts": [
+      {
+        "title": "1922",
+        "url": "https://stephen-king-api.onrender.com/api/book/177"
+      }
+    ]
+  },
+  {
+    "id": 60,
+    "name": "Eldred Jonas",
+    "gender": "Male",
+    "status": "Alive",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "The Dark Tower",
+      "Villains",
+      "Antagonists"
+    ],
+    "created_at": "2023-11-13T23:49:29.787Z",
+    "books": [
+      {
+        "title": "The Dark Tower IV: Wizard and Glass",
+        "url": "https://stephen-king-api.onrender.com/api/book/34"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 61,
+    "name": "Raymond Andrew Joubert",
+    "gender": "Male",
+    "status": "Alive",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Residents of Maine",
+      "Gerald's Game",
+      "Villains",
+      "Antagonists",
+      "Victims",
+      "Characters with mental illness"
+    ],
+    "created_at": "2023-11-13T23:49:29.902Z",
+    "books": [
+      {
+        "title": "Gerald's Game",
+        "url": "https://stephen-king-api.onrender.com/api/book/27"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 62,
+    "name": "The Kid",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Villains",
+      "Antagonists"
+    ],
+    "created_at": "2023-11-13T23:49:30.009Z",
+    "books": [
+      {
+        "title": "The Stand",
+        "url": "https://stephen-king-api.onrender.com/api/book/5"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 63,
+    "name": "Damon Killian",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Villains",
+      "Antagonists"
+    ],
+    "created_at": "2023-11-13T23:49:30.123Z",
+    "books": [
+      {
+        "title": "The Running Man",
+        "url": "https://stephen-king-api.onrender.com/api/book/11"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 64,
+    "name": "Harold Lauder",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Unsourced quotes",
+      "Ogunquit residents",
+      "Residents of Maine",
+      "Antagonists",
+      "Villains",
+      "The Stand"
+    ],
+    "created_at": "2023-11-13T23:49:30.239Z",
+    "books": [
+      {
+        "title": "The Stand",
+        "url": "https://stephen-king-api.onrender.com/api/book/5"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 65,
+    "name": "Richard Lawson",
+    "gender": null,
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Unsourced quotes",
+      "Sometimes They Come Back",
+      "Antagonists",
+      "Villains",
+      "Bullies"
+    ],
+    "created_at": "2023-11-13T23:49:30.356Z",
+    "books": [],
+    "shorts": [
+      {
+        "title": "Sometimes They Come Back",
+        "url": "https://stephen-king-api.onrender.com/api/book/47"
+      }
+    ]
+  },
+  {
+    "id": 66,
+    "name": "Brian Lippy",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Villains",
+      "From a Buick 8"
+    ],
+    "created_at": "2023-11-13T23:49:30.470Z",
+    "books": [
+      {
+        "title": "From a Buick 8",
+        "url": "https://stephen-king-api.onrender.com/api/book/39"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 67,
+    "name": "Little Sisters",
+    "gender": null,
+    "status": "Alive",
+    "types_id": 2,
+    "notes": [
+      "Organizations",
+      "The Dark Tower novels",
+      "Villains"
+    ],
+    "created_at": "2023-11-13T23:49:30.586Z",
+    "books": [],
+    "shorts": [
+      {
+        "title": "The Little Sisters of Eluria",
+        "url": "https://stephen-king-api.onrender.com/api/book/139"
+      }
+    ]
+  },
+  {
+    "id": 68,
+    "name": "Lester Lowe",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 3,
+    "notes": [
+      "Characters",
+      "Reverends",
+      "Werewolves",
+      "Antagonists",
+      "Villains"
+    ],
+    "created_at": "2023-11-13T23:49:30.702Z",
+    "books": [
+      {
+        "title": "Cycle of the Werewolf",
+        "url": "https://stephen-king-api.onrender.com/api/book/15"
+      }
+    ],
+    "shorts": [
+      {
+        "title": "Cycle of the Werewolf",
+        "url": "https://stephen-king-api.onrender.com/api/book/91"
+      }
+    ]
+  },
+  {
+    "id": 69,
+    "name": "Richard P. Macklin",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Derry residents",
+      "Villains"
+    ],
+    "created_at": "2023-11-13T23:49:30.817Z",
+    "books": [
+      {
+        "title": "It",
+        "url": "https://stephen-king-api.onrender.com/api/book/19"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 70,
+    "name": "The Major",
+    "gender": "Male",
+    "status": "Alive",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Military",
+      "Villains"
+    ],
+    "created_at": "2023-11-13T23:49:30.930Z",
+    "books": [
+      {
+        "title": "The Long Walk",
+        "url": "https://stephen-king-api.onrender.com/api/book/6"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 71,
+    "name": "Malcolm Janus",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Murderers",
+      "The Dead Zone",
+      "Villains"
+    ],
+    "created_at": "2023-11-13T23:49:31.048Z",
+    "books": [
+      {
+        "title": "The Dead Zone",
+        "url": "https://stephen-king-api.onrender.com/api/book/7"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 72,
+    "name": "Alvin Marsh",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "IT",
+      "Widows",
+      "Derry residents",
+      "Status dependant on version",
+      "Villains",
+      "Antagonists",
+      "Rapists"
+    ],
+    "created_at": "2023-11-13T23:49:31.163Z",
+    "books": [
+      {
+        "title": "It",
+        "url": "https://stephen-king-api.onrender.com/api/book/19"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 73,
+    "name": "Charlie McGee",
+    "gender": "Female",
+    "status": "Alive",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "ESPers",
+      "Seekers of vengeance",
+      "Heroes",
+      "Firestarter",
+      "Alive",
+      "Villains",
+      "Victims"
+    ],
+    "created_at": "2023-11-13T23:49:31.277Z",
+    "books": [
+      {
+        "title": "Firestarter",
+        "url": "https://stephen-king-api.onrender.com/api/book/8"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 74,
+    "name": "John \"Ace\" Merrill",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Castle Rock residents",
+      "Leaders",
+      "Bullies",
+      "Seekers of vengeance",
+      "TB/SBM Characters",
+      "Residents of Maine",
+      "Stand By Me",
+      "Gang Leaders",
+      "Antagonists",
+      "Castle Rock",
+      "Villains"
+    ],
+    "created_at": "2023-11-13T23:49:31.390Z",
+    "books": [],
+    "shorts": [
+      {
+        "title": "The Body",
+        "url": "https://stephen-king-api.onrender.com/api/book/84"
+      }
+    ]
+  },
+  {
+    "id": 75,
+    "name": "Vic Mooney",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Unsourced quotes",
+      "Ewen High School students",
+      "Residents of Maine",
+      "Chamberlain residents",
+      "Alive",
+      "Bullies",
+      "Villains",
+      "Bate High School students",
+      "Name-continuity",
+      "Protagonists",
+      "Heroes",
+      "Antagonists",
+      "Carrie"
+    ],
+    "created_at": "2023-11-13T23:49:31.506Z",
+    "books": [
+      {
+        "title": "Carrie",
+        "url": "https://stephen-king-api.onrender.com/api/book/1"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 76,
+    "name": "Jack Mort",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Murderers",
+      "Villains",
+      "The Dark Tower",
+      "Antagonists"
+    ],
+    "created_at": "2023-11-13T23:49:31.628Z",
+    "books": [
+      {
+        "title": "The Dark Tower II: The Drawing of the Three",
+        "url": "https://stephen-king-api.onrender.com/api/book/20"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 77,
+    "name": "The Mortimer Snerds",
+    "gender": null,
+    "status": "Deceased",
+    "types_id": 5,
+    "notes": [
+      "Villains",
+      "Victims",
+      "Bullies",
+      "The Rage characters",
+      "The Rage: Carrie 2",
+      "Name-continuity",
+      "Unknown fates",
+      "Antagonists",
+      "Carrie"
+    ],
+    "created_at": "2023-11-13T23:49:31.750Z",
+    "books": [
+      {
+        "title": "Carrie",
+        "url": "https://stephen-king-api.onrender.com/api/book/1"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 78,
+    "name": "Mother of the Null",
+    "gender": null,
+    "status": "Alive",
+    "types_id": 3,
+    "notes": [
+      "Characters",
+      "Villains",
+      "Antagonists"
+    ],
+    "created_at": "2023-11-13T23:49:31.862Z",
+    "books": [
+      {
+        "title": "Revival",
+        "url": "https://stephen-king-api.onrender.com/api/book/54"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 79,
+    "name": "Sally Mueller",
+    "gender": "Female",
+    "status": "Alive",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "IT",
+      "Derry residents",
+      "Residents of Maine",
+      "Bullies",
+      "Villains"
+    ],
+    "created_at": "2023-11-13T23:49:31.981Z",
+    "books": [
+      {
+        "title": "It",
+        "url": "https://stephen-king-api.onrender.com/api/book/19"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 80,
+    "name": "Billy Nolan",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Leaders",
+      "Chamberlain residents",
+      "Bullies",
+      "Characters with mental illness",
+      "Lovers",
+      "Residents of Maine",
+      "Bate High School students",
+      "Ewen High School students",
+      "Villains",
+      "Gang Leaders",
+      "Antagonists",
+      "Victims",
+      "Rapists",
+      "Carrie"
+    ],
+    "created_at": "2023-11-13T23:49:32.092Z",
+    "books": [
+      {
+        "title": "Carrie",
+        "url": "https://stephen-king-api.onrender.com/api/book/1"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 81,
+    "name": "Samuel Norton",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Villains",
+      "Antagonists",
+      "Wardens of Shawshank State Prison"
+    ],
+    "created_at": "2023-11-13T23:49:32.204Z",
+    "books": [],
+    "shorts": [
+      {
+        "title": "Rita Hayworth and Shawshank Redemption",
+        "url": "https://stephen-king-api.onrender.com/api/book/86"
+      }
+    ]
+  },
+  {
+    "id": 82,
+    "name": "The Outsider (Creature)",
+    "gender": null,
+    "status": "Alive",
+    "types_id": 3,
+    "notes": [
+      "Shape-Shifters",
+      "The Outsider Characters",
+      "Villains"
+    ],
+    "created_at": "2023-11-13T23:49:32.316Z",
+    "books": [
+      {
+        "title": "The Outsider",
+        "url": "https://stephen-king-api.onrender.com/api/book/59"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 83,
+    "name": "Victor Pascow",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Pet Sematary"
+    ],
+    "created_at": "2023-11-13T23:49:32.430Z",
+    "books": [
+      {
+        "title": "Pet Sematary",
+        "url": "https://stephen-king-api.onrender.com/api/book/14"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 84,
+    "name": "Sylvia Pittston",
+    "gender": "Female",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Reverends",
+      "Tull residents",
+      "Villains",
+      "Lovers"
+    ],
+    "created_at": "2023-11-13T23:49:32.547Z",
+    "books": [
+      {
+        "title": "The Dark Tower: The Gunslinger",
+        "url": "https://stephen-king-api.onrender.com/api/book/12"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 85,
+    "name": "The Raggedy Man",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Villains"
+    ],
+    "created_at": "2023-11-13T23:49:32.669Z",
+    "books": [
+      {
+        "title": "Cell",
+        "url": "https://stephen-king-api.onrender.com/api/book/44"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 86,
+    "name": "John Rainbird",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Firestarter",
+      "Government employees",
+      "Villains",
+      "Antagonists"
+    ],
+    "created_at": "2023-11-13T23:49:32.793Z",
+    "books": [
+      {
+        "title": "Firestarter",
+        "url": "https://stephen-king-api.onrender.com/api/book/8"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 87,
+    "name": "Rat Man",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Villains",
+      "Antagonists"
+    ],
+    "created_at": "2023-11-13T23:49:32.911Z",
+    "books": [
+      {
+        "title": "The Stand",
+        "url": "https://stephen-king-api.onrender.com/api/book/5"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 88,
+    "name": "Jim Rennie, Jr.",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Police",
+      "Chester's Mill residents",
+      "Residents of Maine",
+      "Characters with mental illness",
+      "Villains",
+      "Antagonists",
+      "Victims",
+      "Rapists",
+      "Under the Dome"
+    ],
+    "created_at": "2023-11-13T23:49:33.030Z",
+    "books": [
+      {
+        "title": "Under the Dome",
+        "url": "https://stephen-king-api.onrender.com/api/book/48"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 89,
+    "name": "Jim Rennie",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Chester's Mill residents",
+      "Politicians",
+      "Murderers",
+      "Residents of Maine",
+      "Villains",
+      "Antagonists",
+      "Under the Dome"
+    ],
+    "created_at": "2023-11-13T23:49:33.149Z",
+    "books": [
+      {
+        "title": "Under the Dome",
+        "url": "https://stephen-king-api.onrender.com/api/book/48"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 90,
+    "name": "Elenor Richmond",
+    "gender": "Female",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Chamberlain residents",
+      "Villains",
+      "Carrie"
+    ],
+    "created_at": "2023-11-13T23:49:33.273Z",
+    "books": [
+      {
+        "title": "Carrie",
+        "url": "https://stephen-king-api.onrender.com/api/book/1"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 91,
+    "name": "Tom Rogan",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Characters with mental illness",
+      "Seekers of vengeance",
+      "Bullies",
+      "IT",
+      "Spouses",
+      "Lovers",
+      "Villains",
+      "Antagonists",
+      "Victims"
+    ],
+    "created_at": "2023-11-13T23:49:33.516Z",
+    "books": [
+      {
+        "title": "It",
+        "url": "https://stephen-king-api.onrender.com/api/book/19"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 92,
+    "name": "Sam (cat)",
+    "gender": null,
+    "status": "Alive",
+    "types_id": 8,
+    "notes": [
+      "Cats",
+      "Villains",
+      "Antagonists"
+    ],
+    "created_at": "2023-11-13T23:49:33.648Z",
+    "books": [],
+    "shorts": [
+      {
+        "title": "The Cat from Hell",
+        "url": "https://stephen-king-api.onrender.com/api/book/55"
+      }
+    ]
+  },
+  {
+    "id": 93,
+    "name": "Sonny Elliman",
+    "gender": "Male",
+    "status": "Alive",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Villains",
+      "Crime"
+    ],
+    "created_at": "2023-11-13T23:49:33.779Z",
+    "books": [
+      {
+        "title": "The Dead Zone",
+        "url": "https://stephen-king-api.onrender.com/api/book/7"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 94,
+    "name": "Rachel Spies",
+    "gender": "Female",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Bullies",
+      "Residents of Maine",
+      "Villains",
+      "Chamberlain residents",
+      "Bate High School students",
+      "Ewen High School students",
+      "Name-continuity",
+      "Unknown fates",
+      "Victims",
+      "Antagonists",
+      "Carrie"
+    ],
+    "created_at": "2023-11-13T23:49:33.905Z",
+    "books": [
+      {
+        "title": "Carrie",
+        "url": "https://stephen-king-api.onrender.com/api/book/1"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 95,
+    "name": "Joe St. George",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Lovers",
+      "Residents of Maine",
+      "Antagonists",
+      "Dolores Claiborne",
+      "Little Tall residents",
+      "Villains"
+    ],
+    "created_at": "2023-11-13T23:49:34.029Z",
+    "books": [
+      {
+        "title": "Dolores Claiborne",
+        "url": "https://stephen-king-api.onrender.com/api/book/28"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 96,
+    "name": "George Stark",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Writers",
+      "Villains",
+      "Twins",
+      "Antagonists"
+    ],
+    "created_at": "2023-11-13T23:49:34.152Z",
+    "books": [
+      {
+        "title": "The Dark Half",
+        "url": "https://stephen-king-api.onrender.com/api/book/23"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 97,
+    "name": "Greg Stillson",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Politicians",
+      "Murderers",
+      "The Dead Zone",
+      "Government employees",
+      "Villains",
+      "Antagonists"
+    ],
+    "created_at": "2023-11-13T23:49:34.279Z",
+    "books": [
+      {
+        "title": "The Dead Zone",
+        "url": "https://stephen-king-api.onrender.com/api/book/7"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 98,
+    "name": "Richard Straker",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Villains",
+      "Jerusalem's Lot residents",
+      "Antagonists"
+    ],
+    "created_at": "2023-11-13T23:49:34.398Z",
+    "books": [
+      {
+        "title": "Salem's Lot",
+        "url": "https://stephen-king-api.onrender.com/api/book/2"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 99,
+    "name": "Jackie Talbot",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Ewen High School students",
+      "Chamberlain residents",
+      "Name-continuity",
+      "Bullies",
+      "Villains",
+      "Residents of Maine",
+      "Bate High School students",
+      "Alive",
+      "Status dependant on version",
+      "Antagonists",
+      "Victims",
+      "Carrie"
+    ],
+    "created_at": "2023-11-13T23:49:34.533Z",
+    "books": [
+      {
+        "title": "Carrie",
+        "url": "https://stephen-king-api.onrender.com/api/book/1"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 100,
+    "name": "The Devil's Dozen",
+    "gender": null,
+    "status": "Alive",
+    "types_id": 5,
+    "notes": [
+      "Villains",
+      "Crime"
+    ],
+    "created_at": "2023-11-13T23:49:34.665Z",
+    "books": [
+      {
+        "title": "The Dead Zone",
+        "url": "https://stephen-king-api.onrender.com/api/book/7"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 101,
+    "name": "Carter Thibodeau",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Chester's Mill residents",
+      "Police",
+      "Residents of Maine",
+      "Villains",
+      "Victims",
+      "Rapists",
+      "Under the Dome"
+    ],
+    "created_at": "2023-11-13T23:49:34.795Z",
+    "books": [
+      {
+        "title": "Under the Dome",
+        "url": "https://stephen-king-api.onrender.com/api/book/48"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 102,
+    "name": "Donna and Mary Lila Grace Thibodeau",
+    "gender": "Female",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Ewen High School students",
+      "Chamberlain residents",
+      "Bullies",
+      "Twins",
+      "Victims",
+      "Residents of Maine",
+      "Villains",
+      "Bate High School students",
+      "Lovers",
+      "Unknown fates",
+      "Antagonists",
+      "Carrie"
+    ],
+    "created_at": "2023-11-13T23:49:34.930Z",
+    "books": [
+      {
+        "title": "Carrie",
+        "url": "https://stephen-king-api.onrender.com/api/book/1"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 103,
+    "name": "Tom Mahout",
+    "gender": "Male",
+    "status": "Alive",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Residents of Maine",
+      "Villains",
+      "Antagonists",
+      "Gerald's Game"
+    ],
+    "created_at": "2023-11-13T23:49:35.056Z",
+    "books": [
+      {
+        "title": "Gerald's Game",
+        "url": "https://stephen-king-api.onrender.com/api/book/27"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 104,
+    "name": "Tommyknockers",
+    "gender": null,
+    "status": "Alive",
+    "types_id": 4,
+    "notes": [
+      "Villains",
+      "The Tommyknockers"
+    ],
+    "created_at": "2023-11-13T23:49:35.173Z",
+    "books": [
+      {
+        "title": "The Tommyknockers",
+        "url": "https://stephen-king-api.onrender.com/api/book/22"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 105,
+    "name": "Craig Toomey",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Characters with mental illness",
+      "Villains",
+      "Crime",
+      "Antagonists"
+    ],
+    "created_at": "2023-11-13T23:49:35.311Z",
+    "books": [],
+    "shorts": [
+      {
+        "title": "The Langoliers",
+        "url": "https://stephen-king-api.onrender.com/api/book/114"
+      }
+    ]
+  },
+  {
+    "id": 106,
+    "name": "Jack Torrance",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Writers",
+      "Teachers",
+      "Spouses",
+      "Lovers",
+      "The Shining",
+      "Characters with mental illness",
+      "Villains",
+      "Ghosts",
+      "Heroes",
+      "Doctor Sleep",
+      "Name-continuity",
+      "Antagonists",
+      "Victims",
+      "Harassers"
+    ],
+    "created_at": "2023-11-13T23:49:35.454Z",
+    "books": [
+      {
+        "title": "The Shining",
+        "url": "https://stephen-king-api.onrender.com/api/book/3"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 107,
+    "name": "Christopher Unwin",
+    "gender": "Male",
+    "status": "Alive",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Bullies",
+      "Derry residents",
+      "Residents of Maine",
+      "IT",
+      "Villains"
+    ],
+    "created_at": "2023-11-13T23:49:35.580Z",
+    "books": [
+      {
+        "title": "It",
+        "url": "https://stephen-king-api.onrender.com/api/book/19"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 108,
+    "name": "Jessica Upshaw",
+    "gender": "Female",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Bullies",
+      "Villains",
+      "Residents of Maine",
+      "Chamberlain residents",
+      "Bate High School students",
+      "Ewen High School students",
+      "Name-continuity",
+      "Unknown fates",
+      "Antagonists",
+      "Carrie"
+    ],
+    "created_at": "2023-11-13T23:49:35.756Z",
+    "books": [
+      {
+        "title": "Carrie",
+        "url": "https://stephen-king-api.onrender.com/api/book/1"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 109,
+    "name": "Norma Watson",
+    "gender": "Female",
+    "status": "Alive",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Bullies",
+      "Chamberlain residents",
+      "Victims",
+      "Villains",
+      "Status dependant on version",
+      "Antagonists",
+      "Carrie"
+    ],
+    "created_at": "2023-11-13T23:49:35.954Z",
+    "books": [
+      {
+        "title": "Carrie",
+        "url": "https://stephen-king-api.onrender.com/api/book/1"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 110,
+    "name": "Wendigo",
+    "gender": "Male",
+    "status": "Alive",
+    "types_id": 3,
+    "notes": [
+      "Pet Sematary",
+      "Villains"
+    ],
+    "created_at": "2023-11-13T23:49:36.153Z",
+    "books": [
+      {
+        "title": "Pet Sematary",
+        "url": "https://stephen-king-api.onrender.com/api/book/14"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 111,
+    "name": "Percy Wetmore",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "The Green Mile",
+      "Villains",
+      "Antagonists",
+      "The green mile villains"
+    ],
+    "created_at": "2023-11-13T23:49:36.274Z",
+    "books": [
+      {
+        "title": "The Green Mile",
+        "url": "https://stephen-king-api.onrender.com/api/book/31"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 112,
+    "name": "William Wharton",
+    "gender": "Male",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Villains",
+      "The Green Mile villlains"
+    ],
+    "created_at": "2023-11-13T23:49:36.386Z",
+    "books": [
+      {
+        "title": "The Green Mile",
+        "url": "https://stephen-king-api.onrender.com/api/book/31"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 113,
+    "name": "Margaret White",
+    "gender": "Female",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Unsourced quotes",
+      "Spouses",
+      "Widows",
+      "Characters with mental illness",
+      "Chamberlain residents",
+      "Residents of Maine",
+      "Motton residents",
+      "Villains",
+      "Antagonists",
+      "Victims",
+      "Carrie"
+    ],
+    "created_at": "2023-11-13T23:49:36.505Z",
+    "books": [
+      {
+        "title": "Carrie",
+        "url": "https://stephen-king-api.onrender.com/api/book/1"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 114,
+    "name": "Annie Wilkes",
+    "gender": "Female",
+    "status": "Deceased",
+    "types_id": 1,
+    "notes": [
+      "Characters",
+      "Villains",
+      "Characters with mental illness",
+      "Misery Characters",
+      "Antagonists",
+      "Castle Rock",
+      "Murderers"
+    ],
+    "created_at": "2023-11-13T23:49:36.623Z",
+    "books": [
+      {
+        "title": "Misery",
+        "url": "https://stephen-king-api.onrender.com/api/book/21"
+      }
+    ],
+    "shorts": []
+  },
+  {
+    "id": 115,
+    "name": "Tim Youngblood",
+    "gender": "Male",
+    "status": "Alive",
+    "types_id": 1,
+    "notes": [
+      "Stubs",
+      "Characters",
+      "Villains"
+    ],
+    "created_at": "2023-11-13T23:49:36.745Z",
+    "books": [],
+    "shorts": [
+      {
+        "title": "Rita Hayworth and Shawshank Redemption",
+        "url": "https://stephen-king-api.onrender.com/api/book/86"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
- Added in-memory caching to `request.js` to minimize API calls.
- Created a script `scripts/backupData.js` to back up 'villains', 'shorts', and 'books' data to JSON files.
- Added a `backup-data` npm script to run the backup.