### PR TITLE
Fix: Prevent mass Google API calls and improve image handling

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,6 +14,10 @@ const nextConfig = {
         protocol: 'https',
         hostname: 'upload.wikimedia.org',
       },
+      {
+        protocol: 'https',
+        hostname: 'via.placeholder.com',
+      },
     ],
   },
 };

--- a/src/app/components/ContentDisplay.js
+++ b/src/app/components/ContentDisplay.js
@@ -2,7 +2,7 @@
 import ListItem from './ListItem';
 import ImageItem from './ImageItem';
 
-const ContentDisplay = ({ items, view = 'list', columns = [] }) => { // Added columns prop
+const ContentDisplay = ({ items, view = 'list', columns = [], detailedBooksData, fetchBookDetails }) => { // Added detailedBooksData and fetchBookDetails
   if (!items || items.length === 0) {
     return <p className="text-[var(--text-color)] opacity-70 text-center py-8">No items to display.</p>;
   }
@@ -11,6 +11,8 @@ const ContentDisplay = ({ items, view = 'list', columns = [] }) => { // Added co
     if (columns.length === 0) {
       return <p className="text-[var(--accent-color)] text-center py-8">List view selected, but no column definitions provided.</p>;
     }
+    // For list view, we are not implementing lazy loading of images per cell in this iteration.
+    // If needed, ListItem or a specific cell component within it would need similar logic to ImageItem.
     return (
       <div className="overflow-x-auto shadow-md sm:rounded-lg">
         <table className="min-w-full w-full text-left text-sm text-[var(--text-color)] opacity-90">
@@ -24,12 +26,12 @@ const ContentDisplay = ({ items, view = 'list', columns = [] }) => { // Added co
             </tr>
           </thead>
           <tbody className="divide-y divide-[var(--sk-shadow-light)] dark:divide-[var(--sk-shadow-dark)]">
-            {items.map((item, index) => ( 
-              <ListItem 
-                key={item.id || item.title || index} 
-                item={item} 
-                columns={columns} // Pass columns to ListItem
-                rowIndex={index} // For zebra striping
+            {items.map((item, index) => (
+              <ListItem
+                key={item.id || item.title || index}
+                item={item}
+                columns={columns}
+                rowIndex={index}
               />
             ))}
           </tbody>
@@ -39,11 +41,17 @@ const ContentDisplay = ({ items, view = 'list', columns = [] }) => { // Added co
   }
 
   if (view === 'grid') {
-    // Grid view remains unchanged, does not use 'columns' prop in the same way
     return (
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4 md:gap-6">
         {items.map((item) => (
-          <ImageItem key={item.id || item.title} item={item} />
+          <ImageItem
+            key={item.id || item.title}
+            item={item}
+            // Pass the specific detailed data for this item, if available
+            detailedData={detailedBooksData && detailedBooksData[item.id] ? detailedBooksData[item.id] : null}
+            // Pass the callback to trigger fetching details when visible
+            onVisible={fetchBookDetails ? () => fetchBookDetails(item.id) : undefined}
+          />
         ))}
       </div>
     );

--- a/src/app/components/ImageItem.js
+++ b/src/app/components/ImageItem.js
@@ -1,24 +1,75 @@
 // src/app/components/ImageItem.js
-import Image from 'next/image'; // Using next/image for optimization
-import Link from 'next/link'; // Import Link from next/link
+import React, { useEffect, useRef, useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
 
-const ImageItem = ({ item }) => {
-  const { title, imageUrl, linkUrl } = item;
+const ImageItem = ({ item, detailedData, onVisible }) => {
+  const { title, linkUrl } = item; // Initial imageUrl might be undefined or a placeholder
+  const placeholderRef = useRef(null);
+  const [isVisible, setIsVisible] = useState(false);
+  const [hasBeenVisible, setHasBeenVisible] = useState(false);
+
+  useEffect(() => {
+    // If detailedData is already provided (e.g. from cache, or loaded very quickly),
+    // no need for observer for this item if it means it's already loaded.
+    // However, onVisible might still be used for other purposes by parent.
+    // We only want to trigger onVisible *once* when it first becomes visible.
+    if (hasBeenVisible) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          if (onVisible && !hasBeenVisible) {
+            onVisible();
+            setHasBeenVisible(true); // Ensure onVisible is called only once
+          }
+          // No need to unobserve if we only want to trigger once
+          // observer.unobserve(entry.target);
+        }
+      },
+      {
+        rootMargin: '0px',
+        threshold: 0.1, // Trigger when 10% of the item is visible
+      }
+    );
+
+    if (placeholderRef.current) {
+      observer.observe(placeholderRef.current);
+    }
+
+    return () => {
+      if (placeholderRef.current) {
+        observer.unobserve(placeholderRef.current);
+      }
+      observer.disconnect();
+    };
+  }, [onVisible, hasBeenVisible]);
+
+  // Determine the image URL to use
+  // Prioritize detailedData if available, otherwise use item.imageUrl (initial)
+  let displayImageUrl = detailedData?.largeCoverImageUrl || detailedData?.coverImageUrl || item.imageUrl;
+
+  // Ensure displayImageUrl is a non-empty string before passing to Image component.
+  // Also handle "NO_COVER_AVAILABLE" explicitly to render placeholder.
+  const isValidImageUrl = typeof displayImageUrl === 'string' && displayImageUrl.trim() !== '' && displayImageUrl !== "NO_COVER_AVAILABLE";
 
   const content = (
-    <div className="group relative aspect-[3/4] w-full bg-[var(--background-color)] border border-[var(--border-color)] rounded-lg overflow-hidden shadow-md hover:shadow-xl transition-shadow duration-300">
-      {imageUrl ? (
+    <div ref={placeholderRef} className="group relative aspect-[3/4] w-full bg-[var(--background-color)] border border-[var(--border-color)] rounded-lg overflow-hidden shadow-md hover:shadow-xl transition-shadow duration-300">
+      {(isVisible || isValidImageUrl) && isValidImageUrl ? (
         <Image
-          src={imageUrl}
+          src={displayImageUrl} // Now guaranteed to be a valid string if this branch is taken
           alt={title || 'Item image'}
           layout="fill"
           objectFit="cover"
           className="bg-[var(--sk-shadow-light)] dark:bg-[var(--sk-shadow-dark)] transition-transform duration-300 group-hover:scale-105"
+          priority={false} // Explicitly set priority to false for lazy-loaded images
         />
       ) : (
         <div className="w-full h-full flex items-center justify-center bg-[var(--sk-shadow-light)] dark:bg-[var(--sk-shadow-dark)]">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-12 h-12 text-[var(--text-color)] opacity-50">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" /> {/* Simple X as placeholder */}
+          {/* Placeholder content, e.g., a spinner or a static icon */}
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-12 h-12 text-[var(--text-color)] opacity-50 animate-pulse">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 001.5-1.5V6a1.5 1.5 0 00-1.5-1.5H3.75A1.5 1.5 0 002.25 6v12a1.5 1.5 0 001.5 1.5zm10.5-11.25h.008v.008h-.008V8.25zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z" />
           </svg>
         </div>
       )}

--- a/src/app/pages/books/BookListClient.js
+++ b/src/app/pages/books/BookListClient.js
@@ -1,17 +1,12 @@
 "use client";
 
-import React, { useState, useMemo, Suspense } from 'react';
+import React, { useState, useMemo, useEffect } from 'react'; // Added useEffect
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-// import Image from 'next/image'; // No longer directly used here, ContentDisplay handles images
 import SearchAndSortControls from '@/app/components/SearchAndSortControls';
-import ViewSwitcher from '@/app/components/ViewSwitcher'; // Added
-import ContentDisplay from '@/app/components/ContentDisplay'; // Added
-
-
-// const FilterPopup = dynamic(() => import('./FilterPopup'), { // FilterPopup component removed
-//   suspense: true,
-// });
+import ViewSwitcher from '@/app/components/ViewSwitcher';
+import ContentDisplay from '@/app/components/ContentDisplay';
+import Request from '@/app/components/request'; // Import Request
 
 /**
  * BookListClient component for displaying and filtering a list of books.
@@ -20,16 +15,17 @@ import ContentDisplay from '@/app/components/ContentDisplay'; // Added
  * @returns {JSX.Element} The BookListClient component.
  */
 export default function BookListClient({ initialBooks }) {
-   // State variable for the search term
-   const [searchTerm, setSearchTerm] = useState('');
-   // New sortConfig state for SearchAndSortControls
-   const [sortConfig, setSortConfig] = useState({ key: 'Title', direction: 'ascending' });
+  const [searchTerm, setSearchTerm] = useState('');
+  const [sortConfig, setSortConfig] = useState({ key: 'Title', direction: 'ascending' });
   const [selectedYear, setSelectedYear] = useState('');
   const [selectedPublisher, setSelectedPublisher] = useState('');
   const [minPages, setMinPages] = useState('');
   const [maxPages, setMaxPages] = useState('');
-  const [currentView, setCurrentView] = useState('grid'); // Added state for view, default to grid
+  const [currentView, setCurrentView] = useState('grid');
   const router = useRouter();
+
+  // State to hold detailed book data fetched on demand
+  const [detailedBooksData, setDetailedBooksData] = useState({});
 
   const bookColumns = [
     { key: 'title', label: 'Title', isLink: true },
@@ -37,30 +33,51 @@ export default function BookListClient({ initialBooks }) {
     { key: 'yearDisplay', label: 'Year' }
   ];
 
-  // Memoized lists for dropdowns (moved from FilterPopup)
   const uniqueYears = useMemo(() => {
     if (!initialBooks?.data || !Array.isArray(initialBooks.data)) return [];
     const years = new Set(initialBooks.data.map(book => book.Year).filter(Boolean));
-    return Array.from(years).sort((a, b) => b - a); // Descending order
+    return Array.from(years).sort((a, b) => b - a);
   }, [initialBooks]);
 
   const uniquePublishers = useMemo(() => {
     if (!initialBooks?.data || !Array.isArray(initialBooks.data)) return [];
     const publishers = new Set(initialBooks.data.map(book => book.Publisher).filter(Boolean));
-    return Array.from(publishers).sort(); // Ascending order
+    return Array.from(publishers).sort();
   }, [initialBooks]);
 
-  // Handler for resetting filters (moved and adapted from FilterPopup)
   const handleResetFilters = () => {
     setSelectedYear('');
     setSelectedPublisher('');
     setMinPages('');
     setMaxPages('');
-    // setSearchTerm(''); // Optionally reset search term as well
-    // setSortOrder('alphabetical'); // Optionally reset sort order
   };
 
-  // Memoized variable for filtered and processed books
+  // Function to fetch detailed data for a single book
+  const fetchBookDetails = async (bookId) => {
+    if (detailedBooksData[bookId] && !detailedBooksData[bookId].isLoading) {
+      // console.log(`[INFO] BookListClient: Data for book ${bookId} already fetched or being fetched.`);
+      return; // Already fetched or currently fetching
+    }
+
+    // console.log(`[INFO] BookListClient: Fetching details for book ${bookId}...`);
+    setDetailedBooksData(prev => ({ ...prev, [bookId]: { isLoading: true } })); // Mark as loading
+
+    try {
+      const result = await Request(`book/${bookId}`); // Use the Request utility
+      if (result && result.data) {
+        // console.log(`[INFO] BookListClient: Successfully fetched details for book ${bookId}.`);
+        setDetailedBooksData(prev => ({ ...prev, [bookId]: result.data }));
+      } else {
+        console.warn(`[WARN] BookListClient: No data returned for book ${bookId}. Result:`, result);
+        setDetailedBooksData(prev => ({ ...prev, [bookId]: { error: true, isLoading: false } }));
+      }
+    } catch (error) {
+      console.error(`[ERROR] BookListClient: Error fetching details for book ${bookId}:`, error);
+      setDetailedBooksData(prev => ({ ...prev, [bookId]: { error: true, isLoading: false } }));
+    }
+  };
+
+
   const processedBooks = useMemo(() => {
     if (!initialBooks || !initialBooks.data || !Array.isArray(initialBooks.data)) return [];
 
@@ -97,23 +114,22 @@ export default function BookListClient({ initialBooks }) {
       });
     }
     
-    // Transform data for ContentDisplay (List and Grid views)
-    return booksArray.map(book => ({
-      id: book.id,
-      title: book.Title,
-      // For GridView
-      imageUrl: book.coverImageUrl && book.coverImageUrl !== "NO_COVER_AVAILABLE" ? book.coverImageUrl : null,
-      // For ListView (tabular)
-      authorsDisplay: book.authors ? book.authors.join(', ') : 'Unknown Author',
-      yearDisplay: book.Year ? String(book.Year) : 'Unknown Year',
-      // For general linking
-      linkUrl: `/pages/books/${book.id}`,
-      // The 'description' field for ListItem (if it were still generic) is now split into authorsDisplay and yearDisplay for the table.
-      // If ImageItem needs a description, it would typically use the 'title' or we could add a specific one.
-      // For ListItem (if it were still the old version), it would need this combined description:
-      // description: `${book.authors ? book.authors.join(', ') : 'Unknown Author'} - ${book.Year || 'Unknown Year'}`,
-    }));
-  }, [initialBooks, searchTerm, sortConfig, selectedYear, selectedPublisher, minPages, maxPages]);
+    return booksArray.map(book => {
+      const details = detailedBooksData[book.id];
+      return {
+        id: book.id,
+        title: book.Title,
+        // Use detailed image URL if available, otherwise the one from initialBooks (which might be null or basic)
+        imageUrl: (details && !details.isLoading && !details.error) ? (details.largeCoverImageUrl || details.coverImageUrl) : (book.coverImageUrl && book.coverImageUrl !== "NO_COVER_AVAILABLE" ? book.coverImageUrl : null),
+        authorsDisplay: book.authors ? book.authors.join(', ') : (details && details.authors ? details.authors.join(', ') : 'Unknown Author'),
+        yearDisplay: book.Year ? String(book.Year) : (details && details.Year ? String(details.Year) : 'Unknown Year'),
+        linkUrl: `/pages/books/${book.id}`,
+        // Pass through loading/error state if needed by ImageItem for more specific placeholders
+        isLoading: details?.isLoading,
+        hasError: details?.error,
+      };
+    });
+  }, [initialBooks, searchTerm, sortConfig, selectedYear, selectedPublisher, minPages, maxPages, detailedBooksData]);
 
   const requestSort = (key) => {
     let direction = 'ascending';


### PR DESCRIPTION
- I modified `request.js` to only fetch full Google Books data for single book requests, preventing mass API calls for book lists.
- I implemented lazy loading for book cover images on the main books list page (`BookListClient.js`, `ContentDisplay.js`, `ImageItem.js`) using Intersection Observer to fetch details on demand.
- I updated `next.config.mjs` to include `via.placeholder.com` in image remote patterns.
- I made `ImageItem.js` more robust in handling potentially invalid or missing image URLs before rendering `next/image`.

This addresses issues leading to 429 rate limit errors from Google Books API and subsequent errors related to image component src and configuration.